### PR TITLE
Implement PDF BOM import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ curl -X POST http://localhost:8000/bom/items \
      -d '{"part_number":"ABC-123","description":"10 \u00b5F Cap","quantity":2}'
 ```
 
+Import a BOM PDF:
+```bash
+curl -F file=@sample.pdf http://localhost:8000/bom/import
+```
+The parser assumes table columns are separated by multiple spaces or tabs. Real
+world PDFs may require tweaks.
+
 ### BOMItem fields
 - **part_number**: unique identifier for the part (string, required)
 - **description**: human-friendly description (string, required)

--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,0 +1,42 @@
+import fitz
+import re
+
+
+def extract_bom_text(pdf_bytes: bytes) -> str:
+    """Extract all text from a PDF byte string using PyMuPDF."""
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        texts = [page.get_text() for page in doc]
+    return "\n".join(texts)
+
+
+def parse_bom_lines(text: str) -> list[dict]:
+    """Parse raw BOM text into a list of dictionaries.
+
+    This simplistic parser assumes columns are separated by multiple spaces or
+    tabs. Lines not matching the expected pattern are skipped.
+    """
+    items = []
+    for line in text.splitlines():
+        # Collapse multiple tabs/spaces into single tab for easier split
+        parts = re.split(r"\s{2,}|\t+", line.strip())
+        if len(parts) < 3:
+            continue
+        part_number = parts[0].strip()
+        description = parts[1].strip()
+        qty_str = parts[2].strip()
+        if not part_number or not description:
+            continue
+        try:
+            quantity = int(re.match(r"\d+", qty_str).group())
+        except Exception:
+            continue
+        reference = parts[3].strip() if len(parts) > 3 and parts[3].strip() else None
+        items.append(
+            {
+                "part_number": part_number,
+                "description": description,
+                "quantity": quantity,
+                "reference": reference,
+            }
+        )
+    return items

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ sqlmodel           # SQLAlchemy + Pydantic
 psycopg2-binary    # PostgreSQL driver
 pytest
 httpx
+pymupdf
+python-multipart

--- a/tests/test_pdf_import.py
+++ b/tests/test_pdf_import.py
@@ -1,0 +1,51 @@
+# root: tests/test_pdf_import.py
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import sqlalchemy
+import pytest
+import fitz
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.main as main
+from app.pdf_utils import parse_bom_lines, extract_bom_text
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    test_engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = test_engine
+    SQLModel.metadata.create_all(test_engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+def test_extract_and_parse():
+    text = "PN1    Resistor 1k    2    R1\nPN2    Cap 1uF    5    C1"
+    items = parse_bom_lines(text)
+    assert items == [
+        {"part_number": "PN1", "description": "Resistor 1k", "quantity": 2, "reference": "R1"},
+        {"part_number": "PN2", "description": "Cap 1uF", "quantity": 5, "reference": "C1"},
+    ]
+
+
+def test_import_endpoint(client):
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "PN9    Widget    3    R9")
+    pdf_bytes = doc.tobytes()
+
+    files = {"file": ("sample.pdf", pdf_bytes, "application/pdf")}
+    response = client.post("/bom/import", files=files)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["part_number"] == "PN9"
+    # ensure item persisted
+    list_resp = client.get("/bom/items")
+    assert any(i["part_number"] == "PN9" for i in list_resp.json())


### PR DESCRIPTION
## Summary
- add PyMuPDF and python-multipart dependencies
- implement PDF text extraction and parser utilities
- expose `/bom/import` endpoint to load BOM items from uploaded PDF
- include unit tests for parsing and endpoint behaviour
- document import endpoint in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684587146190832cbafd3abdd51a6c8a