### PR TITLE
Implement full CRUD with search and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,35 @@ curl -X POST http://localhost:8000/bom/items \
      -d '{"part_number":"ABC-123","description":"10 \u00b5F Cap","quantity":2}'
 ```
 
+Retrieve a single item:
+```bash
+curl http://localhost:8000/bom/items/1
+```
+
+Update an item completely:
+```bash
+curl -X PUT http://localhost:8000/bom/items/1 \
+     -H "Content-Type: application/json" \
+     -d '{"part_number":"ABC-123","description":"Cap 22uF","quantity":3}'
+```
+
+Patch an item:
+```bash
+curl -X PATCH http://localhost:8000/bom/items/1 \
+     -H "Content-Type: application/json" \
+     -d '{"quantity":5}'
+```
+
+Delete an item:
+```bash
+curl -X DELETE http://localhost:8000/bom/items/1
+```
+
+List items with search and pagination:
+```bash
+curl "http://localhost:8000/bom/items?search=Cap&min_qty=1&max_qty=10&skip=0&limit=20"
+```
+
 Import a BOM PDF:
 ```bash
 curl -F file=@sample.pdf http://localhost:8000/bom/import

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,9 @@
 # root: app/main.py
-from fastapi import FastAPI, status, UploadFile, File
+from fastapi import FastAPI, status, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import SQLModel, Field, Session, create_engine, select
-from sqlalchemy import text
+from sqlalchemy import text, UniqueConstraint
+from sqlalchemy.exc import IntegrityError
 
 from .pdf_utils import extract_bom_text, parse_bom_lines
 
@@ -31,11 +32,28 @@ class BOMItem(BOMItemBase, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
 
+    __table_args__ = (UniqueConstraint("part_number", "reference", name="uix_part_ref"),)
+
 
 class BOMItemCreate(BOMItemBase):
     """Schema for creating items via the API."""
 
     pass
+
+
+class BOMItemRead(BOMItemBase):
+    """Schema returned from the API."""
+
+    id: int
+
+
+class BOMItemUpdate(SQLModel):
+    """Schema for updating items (all fields optional)."""
+
+    part_number: str | None = Field(default=None, min_length=1)
+    description: str | None = Field(default=None, min_length=1)
+    quantity: int | None = Field(default=None, ge=1)
+    reference: str | None = None
 
 
 def init_db() -> None:
@@ -78,29 +96,129 @@ def health() -> dict[str, str]:
     return {"api": "ok", "db": db_status}
 
 
-@app.get("/bom/items", response_model=list[BOMItem])
-def list_items() -> list[BOMItem]:
-    """Return all BOM items."""
+@app.get("/bom/items", response_model=list[BOMItemRead])
+def list_items(
+    search: str | None = None,
+    min_qty: int | None = None,
+    max_qty: int | None = None,
+    skip: int = 0,
+    limit: int = 50,
+) -> list[BOMItemRead]:
+    """Return BOM items with optional filtering and pagination."""
+
+    if limit > 200:
+        limit = 200
+
+    stmt = select(BOMItem)
+    if search:
+        pattern = f"%{search}%"
+        stmt = stmt.where(
+            (BOMItem.part_number.ilike(pattern))
+            | (BOMItem.description.ilike(pattern))
+        )
+    if min_qty is not None:
+        stmt = stmt.where(BOMItem.quantity >= min_qty)
+    if max_qty is not None:
+        stmt = stmt.where(BOMItem.quantity <= max_qty)
+    stmt = stmt.offset(skip).limit(limit)
 
     with Session(engine) as session:
-        items = session.exec(select(BOMItem)).all()
+        items = session.exec(stmt).all()
     return items
 
 
-@app.post("/bom/items", response_model=BOMItem, status_code=status.HTTP_201_CREATED)
-def create_item(item: BOMItemCreate) -> BOMItem:
+@app.post("/bom/items", response_model=BOMItemRead, status_code=status.HTTP_201_CREATED)
+def create_item(item: BOMItemCreate) -> BOMItemRead:
     """Create a new BOM item."""
 
     db_item = BOMItem.from_orm(item)
     with Session(engine) as session:
         session.add(db_item)
-        session.commit()
+        try:
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Item with this part_number and reference already exists",
+            )
         session.refresh(db_item)
     return db_item
 
 
-@app.post("/bom/import", response_model=list[BOMItem])
-async def import_bom(file: UploadFile = File(...)) -> list[BOMItem]:
+@app.get("/bom/items/{item_id}", response_model=BOMItemRead)
+def get_item(item_id: int) -> BOMItemRead:
+    """Retrieve a single BOM item by ID."""
+
+    with Session(engine) as session:
+        item = session.get(BOMItem, item_id)
+        if not item:
+            raise HTTPException(status_code=404, detail="Item not found")
+        return item
+
+
+@app.put("/bom/items/{item_id}", response_model=BOMItemRead)
+def replace_item(item_id: int, item_in: BOMItemCreate) -> BOMItemRead:
+    """Fully replace an existing BOM item."""
+
+    with Session(engine) as session:
+        db_item = session.get(BOMItem, item_id)
+        if not db_item:
+            raise HTTPException(status_code=404, detail="Item not found")
+        for field, value in item_in.dict().items():
+            setattr(db_item, field, value)
+        try:
+            session.add(db_item)
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Item with this part_number and reference already exists",
+            )
+        session.refresh(db_item)
+        return db_item
+
+
+@app.patch("/bom/items/{item_id}", response_model=BOMItemRead)
+def update_item(item_id: int, item_in: BOMItemUpdate) -> BOMItemRead:
+    """Partially update an existing BOM item."""
+
+    with Session(engine) as session:
+        db_item = session.get(BOMItem, item_id)
+        if not db_item:
+            raise HTTPException(status_code=404, detail="Item not found")
+        update_data = item_in.dict(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_item, field, value)
+        try:
+            session.add(db_item)
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Item with this part_number and reference already exists",
+            )
+        session.refresh(db_item)
+        return db_item
+
+
+@app.delete("/bom/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_item(item_id: int) -> None:
+    """Delete a BOM item."""
+
+    with Session(engine) as session:
+        db_item = session.get(BOMItem, item_id)
+        if not db_item:
+            raise HTTPException(status_code=404, detail="Item not found")
+        session.delete(db_item)
+        session.commit()
+    return None
+
+
+@app.post("/bom/import", response_model=list[BOMItemRead])
+async def import_bom(file: UploadFile = File(...)) -> list[BOMItemRead]:
     """Import BOM items from an uploaded PDF file."""
 
     pdf_bytes = await file.read()
@@ -114,7 +232,14 @@ async def import_bom(file: UploadFile = File(...)) -> list[BOMItem]:
                 continue
             item = BOMItem(**rec)
             session.add(item)
-            session.commit()
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Item with this part_number and reference already exists",
+                )
             session.refresh(item)
             inserted.append(item)
     return inserted

--- a/tests/test_bom_crud.py
+++ b/tests/test_bom_crud.py
@@ -1,0 +1,85 @@
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import sqlalchemy
+import pytest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.main as main
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    test_engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = test_engine
+    SQLModel.metadata.create_all(test_engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+def create_sample_items(client):
+    items = [
+        {"part_number": "PN1", "description": "Resistor", "quantity": 2, "reference": "R1"},
+        {"part_number": "PN2", "description": "Capacitor", "quantity": 5, "reference": "C1"},
+        {"part_number": "FINDME", "description": "Special", "quantity": 1, "reference": "U1"},
+    ]
+    for item in items:
+        client.post("/bom/items", json=item)
+    return items
+
+
+def test_crud_lifecycle(client):
+    payload = {"part_number": "PN10", "description": "Widget", "quantity": 3, "reference": "X1"}
+    create_resp = client.post("/bom/items", json=payload)
+    assert create_resp.status_code == 201
+    item_id = create_resp.json()["id"]
+
+    # GET
+    get_resp = client.get(f"/bom/items/{item_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["part_number"] == payload["part_number"]
+
+    # PUT
+    replacement = {"part_number": "PN10", "description": "Widget v2", "quantity": 4, "reference": "X1"}
+    put_resp = client.put(f"/bom/items/{item_id}", json=replacement)
+    assert put_resp.status_code == 200
+    assert put_resp.json()["description"] == "Widget v2"
+
+    # PATCH
+    patch_resp = client.patch(f"/bom/items/{item_id}", json={"quantity": 6})
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["quantity"] == 6
+
+    # DELETE
+    del_resp = client.delete(f"/bom/items/{item_id}")
+    assert del_resp.status_code == 204
+    get_after = client.get(f"/bom/items/{item_id}")
+    assert get_after.status_code == 404
+
+
+def test_list_search_pagination(client):
+    items = create_sample_items(client)
+    resp = client.get("/bom/items", params={"search": "find", "limit": 2})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["part_number"] == "FINDME"
+
+    # pagination
+    resp_all = client.get("/bom/items", params={"skip": 1, "limit": 1})
+    assert resp_all.status_code == 200
+    assert len(resp_all.json()) == 1
+
+
+def test_duplicate_insert(client):
+    item = {"part_number": "DUP", "description": "Dup Item", "quantity": 1, "reference": "R99"}
+    r1 = client.post("/bom/items", json=item)
+    assert r1.status_code == 201
+    r2 = client.post("/bom/items", json=item)
+    assert r2.status_code == 409
+


### PR DESCRIPTION
## Summary
- add `BOMItemRead` and `BOMItemUpdate` models
- enforce uniqueness on `(part_number, reference)`
- implement search, pagination and CRUD endpoints
- handle duplicates with 409 Conflict
- extend PDF import with uniqueness handling
- document new API usage in README
- add comprehensive CRUD test suite

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684588dd97a0832cabd19ec8ab1a5ce9