### PR TITLE
Implement Quote API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ curl -F file=@sample.pdf http://localhost:8000/bom/import
 The parser assumes table columns are separated by multiple spaces or tabs. Real
 world PDFs may require tweaks.
 
+### Quote
+
+Get a quick time and cost estimate for the current BOM:
+
+```bash
+curl http://localhost:8000/bom/quote
+```
+
 ### BOMItem fields
 - **part_number**: unique identifier for the part (string, required)
 - **description**: human-friendly description (string, required)

--- a/app/quote_utils.py
+++ b/app/quote_utils.py
@@ -1,0 +1,22 @@
+# root: app/quote_utils.py
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+BASE_SETUP_TIME = 60  # seconds
+SEC_PER_COMPONENT = 7
+BASE_COST_USD = 100
+COST_PER_COMP = 0.07
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .main import BOMItem
+
+def calculate_quote(items: list["BOMItem"]) -> dict:
+    """Return rough time and cost estimates for the given BOM items."""
+    total_quantity = sum(getattr(item, "quantity", 0) for item in items)
+    time_sec = BASE_SETUP_TIME + SEC_PER_COMPONENT * total_quantity
+    cost_usd = BASE_COST_USD + COST_PER_COMP * total_quantity
+    return {
+        "total_components": total_quantity,
+        "estimated_time_s": time_sec,
+        "estimated_cost_usd": round(cost_usd, 2),
+    }

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,0 +1,49 @@
+# root: tests/test_quote.py
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import sqlalchemy
+import pytest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.main as main
+from app.quote_utils import calculate_quote
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    test_engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = test_engine
+    SQLModel.metadata.create_all(test_engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+class Dummy:
+    def __init__(self, qty):
+        self.quantity = qty
+
+
+def test_calculate_quote():
+    items = [Dummy(2), Dummy(3)]
+    data = calculate_quote(items)
+    assert data["total_components"] == 5
+    assert data["estimated_time_s"] == 60 + 7 * 5
+    assert data["estimated_cost_usd"] == 100 + 0.07 * 5
+
+
+def test_quote_endpoint(client):
+    client.post("/bom/items", json={"part_number": "P1", "description": "A", "quantity": 2})
+    client.post("/bom/items", json={"part_number": "P2", "description": "B", "quantity": 3})
+    resp = client.get("/bom/quote")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data.keys()) == {"total_components", "estimated_time_s", "estimated_cost_usd"}
+    assert data["total_components"] == 5
+    assert isinstance(data["estimated_time_s"], int)
+    assert isinstance(data["estimated_cost_usd"], float)


### PR DESCRIPTION
## Summary
- add `calculate_quote` helper with placeholder formula
- define `QuoteResponse` schema
- implement `/bom/quote` endpoint
- test quote calculations and endpoint
- document quote endpoint in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684589fe4720832ca1b722f2fb960d51