### PR TITLE
Implement flying-probe test result logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Get a quick time and cost estimate for the current BOM:
 curl http://localhost:8000/bom/quote
 ```
 
+### Test results
+
+Log a new flying-probe test result:
+
+```bash
+curl -X POST http://localhost:8000/testresults \
+     -H "Content-Type: application/json" \
+     -d '{"serial_number":"SN123","result":true}'
+```
+
+List saved results:
+
+```bash
+curl http://localhost:8000/testresults?skip=0&limit=10
+```
+
 ### BOMItem fields
 - **part_number**: unique identifier for the part (string, required)
 - **description**: human-friendly description (string, required)

--- a/tests/test_testresults.py
+++ b/tests/test_testresults.py
@@ -1,0 +1,57 @@
+# root: tests/test_testresults.py
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import sqlalchemy
+import pytest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.main as main
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    test_engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = test_engine
+    SQLModel.metadata.create_all(test_engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+def test_create_test_result(client):
+    payload = {"serial_number": "SN1", "result": True}
+    resp = client.post("/testresults", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["test_id"] == 1
+    assert data["serial_number"] == "SN1"
+    assert data["assembly_id"] == 1
+    assert data["result"] is True
+    assert data["failure_details"] is None
+
+
+def test_list_and_get_results(client):
+    r1 = client.post("/testresults", json={"serial_number": "SN2", "result": True})
+    r2 = client.post(
+        "/testresults",
+        json={"serial_number": "SN3", "result": False, "failure_details": "bad"},
+    )
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+
+    list_resp = client.get("/testresults")
+    assert list_resp.status_code == 200
+    data = list_resp.json()
+    assert len(data) == 2
+
+    single = client.get("/testresults/1")
+    assert single.status_code == 200
+    assert single.json()["serial_number"] == "SN2"
+
+    missing = client.get("/testresults/999")
+    assert missing.status_code == 404


### PR DESCRIPTION
## Summary
- add `TestResult` model and schemas
- expose CRUD-like API endpoints to create and list test results
- document new endpoints in README
- test creation and retrieval of test results

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458b8dff40832c8222be89ebe8bd4f