### PR TITLE
Add traceability helpers and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,17 @@ curl -H "Authorization: Bearer $TOKEN" \
      -d '{"part_number":"ABC-1","description":"Cap","quantity":1}' \
      http://localhost:8000/bom/items
 ```
+
+### Traceability
+
+Identify which boards failed because of a component:
+
+```bash
+curl http://localhost:8000/traceability/component/ABC-123
+```
+
+See the fail status of each BOM item for a board:
+
+```bash
+curl http://localhost:8000/traceability/board/SN123
+```

--- a/app/trace_utils.py
+++ b/app/trace_utils.py
@@ -1,0 +1,55 @@
+# root: app/trace_utils.py
+from __future__ import annotations
+
+
+from sqlmodel import Session, select
+
+
+
+def component_trace(part_number: str, session: Session) -> list[dict]:
+    """Return failed boards referencing the given part number."""
+    from .main import BOMItem, TestResult  # local import to avoid circular
+
+    bom_items = session.exec(select(BOMItem).where(BOMItem.part_number == part_number)).all()
+    if not bom_items:
+        return []
+    refs: list[str] = [b.reference for b in bom_items if b.reference]
+    failed = session.exec(select(TestResult).where(TestResult.result == False)).all()
+    matches: list[dict] = []
+    for tr in failed:
+        details = tr.failure_details or ""
+        if part_number in details or any(ref in details for ref in refs):
+            matches.append({
+                "serial_number": tr.serial_number,
+                "result": tr.result,
+                "failure_details": tr.failure_details,
+            })
+    return matches
+
+
+def board_trace(serial_number: str, session: Session) -> dict:
+    """Return test result info for a board with BOM status annotations."""
+    from .main import BOMItem, TestResult  # local import to avoid circular
+
+    result = session.exec(select(TestResult).where(TestResult.serial_number == serial_number)).first()
+    if not result:
+        return {}
+    bom_items = session.exec(select(BOMItem)).all()
+    details = result.failure_details or ""
+    annotated = []
+    for item in bom_items:
+        status = "FAIL" if (item.part_number in details or (item.reference and item.reference in details)) else "OK"
+        annotated.append({
+            "id": item.id,
+            "part_number": item.part_number,
+            "description": item.description,
+            "quantity": item.quantity,
+            "reference": item.reference,
+            "status": status,
+        })
+    return {
+        "serial_number": result.serial_number,
+        "result": result.result,
+        "failure_details": result.failure_details,
+        "bom": annotated,
+    }

--- a/tests/test_traceability.py
+++ b/tests/test_traceability.py
@@ -1,0 +1,74 @@
+import sqlalchemy
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.main as main
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    test_engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = test_engine
+    SQLModel.metadata.create_all(test_engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_header(client):
+    resp = client.post(
+        "/auth/token",
+        data={"username": "admin", "password": "change_me"},
+    )
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def seed_data(client, auth_header):
+    items = [
+        {"part_number": "PA", "description": "Part A", "quantity": 1, "reference": "R1"},
+        {"part_number": "PB", "description": "Part B", "quantity": 1, "reference": "C1"},
+    ]
+    for item in items:
+        client.post("/bom/items", json=item, headers=auth_header)
+
+    fails = [
+        {"serial_number": "SN1", "result": False, "failure_details": "R1 short"},
+        {"serial_number": "SN2", "result": False, "failure_details": "PB bad"},
+    ]
+    for fr in fails:
+        client.post("/testresults", json=fr, headers=auth_header)
+
+
+
+def test_component_trace(client, auth_header):
+    seed_data(client, auth_header)
+    resp = client.get("/traceability/component/PB")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["serial_number"] == "SN2"
+
+    resp2 = client.get("/traceability/component/PA")
+    assert resp2.status_code == 200
+    assert resp2.json()[0]["serial_number"] == "SN1"
+
+
+def test_board_trace(client, auth_header):
+    seed_data(client, auth_header)
+    resp = client.get("/traceability/board/SN2")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["serial_number"] == "SN2"
+    statuses = {i["part_number"]: i["status"] for i in body["bom"]}
+    assert statuses["PB"] == "FAIL"
+    assert statuses["PA"] == "OK"


### PR DESCRIPTION
## Summary
- implement trace_utils helpers for component & board lookups
- expose `/traceability/component/{part_number}` and `/traceability/board/{serial_number}`
- pydantic schemas for traceability responses
- tests for new traceability endpoints
- document traceability usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458fc65f98832cbbd7b1113aa99579