### PR TITLE
Fix editable install by declaring packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ version = "0.1.0"
 
 [project.scripts]
 bom-gui = "gui.control_center:main"
+
+[tool.setuptools]
+packages = ["app", "gui"]


### PR DESCRIPTION
## Summary
- specify `app` and `gui` packages for setuptools

## Testing
- `pip install -e .`
- `bom-gui --help` *(fails due to missing display but command exists)*

------
https://chatgpt.com/codex/tasks/task_e_68459875f994832c8a87a6daa73f70e5