### PR TITLE
Use sqlite fallback without postgres

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,14 @@
+"""Application configuration values."""
+
+from pathlib import Path
+import os
+
+BASE_DIR = Path(__file__).resolve().parent
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    f"sqlite:///{BASE_DIR / 'bom_dev.db'}",
+)
+
 SECRET_KEY = "secret-key"
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30

--- a/app/main.py
+++ b/app/main.py
@@ -15,13 +15,17 @@ import os
 from openpyxl import Workbook
 
 from .security import verify_password, get_password_hash, create_access_token
-from .config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+from .config import (
+    SECRET_KEY,
+    ALGORITHM,
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+    DATABASE_URL,
+)
 
 from .pdf_utils import extract_bom_text, parse_bom_lines
 from .quote_utils import calculate_quote
 from .trace_utils import component_trace, board_trace
 
-DATABASE_URL = "postgresql://postgres:password@localhost:5432/bom_db"
 engine = create_engine(DATABASE_URL, echo=False)
 scheduler = BackgroundScheduler()
 

--- a/tests/test_startup_sqlite.py
+++ b/tests/test_startup_sqlite.py
@@ -1,0 +1,18 @@
+# root: tests/test_startup_sqlite.py
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
+import importlib
+
+import app.config as config
+import app.main as main
+
+
+def test_startup_with_sqlite(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    SQLModel.metadata.clear()
+    importlib.reload(config)
+    importlib.reload(main)
+    with TestClient(main.app) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"api": "ok", "db": "ok"}


### PR DESCRIPTION
## Summary
- pull `DATABASE_URL` from app.config so config controls DB
- define default sqlite DB URL in config
- test startup with sqlite fallback when no env var

## Testing
- `CI=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459b166fa0832cbb3e0af69fd8714e