### PR TITLE
Add customer-project workflow to web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Nightly backups of these exports are saved under the `backups/` directory.
 ### Browser access
 
 Open `http://localhost:8000/ui/` in a browser to use the built-in web UI.
+A new step-by-step workflow is available at `http://localhost:8000/ui/workflow`.
 Switch between SQLite and Postgres under **Configuration**. Saving
 changes rewrites `~/.bom_platform/settings.toml` and reloads the database
 without restarting Python.

--- a/app/frontend/templates/base.html
+++ b/app/frontend/templates/base.html
@@ -10,6 +10,7 @@
     <nav class="mb-4">
         <a href="/ui/" class="mr-2">Dashboard</a>
         <a href="/ui/bom/" class="mr-2">BOM</a>
+        <a href="/ui/workflow/" class="mr-2">Workflow</a>
         <a href="/ui/import/" class="mr-2">Import</a>
         <a href="/ui/quote/" class="mr-2">Quote</a>
         <a href="/ui/test/" class="mr-2">Test</a>

--- a/app/frontend/templates/workflow.html
+++ b/app/frontend/templates/workflow.html
@@ -1,0 +1,110 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="text-2xl mb-4">Customer Workflow</h1>
+<div id="step1" class="mb-4">
+  <h2 class="font-bold">1. Select Customer</h2>
+  <select id="customer-select" class="border"></select>
+  <input type="text" id="new-customer-name" placeholder="New customer" class="border" />
+  <input type="text" id="new-customer-contact" placeholder="Contact" class="border" />
+  <button id="add-customer" class="bg-blue-500 text-white px-2">Add</button>
+</div>
+<div id="step2" class="mb-4 hidden">
+  <h2 class="font-bold">2. Select Project</h2>
+  <select id="project-select" class="border"></select>
+  <input type="text" id="new-project-name" placeholder="New project" class="border" />
+  <input type="text" id="new-project-desc" placeholder="Description" class="border" />
+  <button id="add-project" class="bg-blue-500 text-white px-2">Add</button>
+</div>
+<div id="step3" class="mb-4 hidden">
+  <h2 class="font-bold">3. Upload BOM</h2>
+  <input type="file" id="bom-file" accept=".csv,.xlsx" class="border" />
+  <button id="upload-bom" class="bg-blue-500 text-white px-2">Upload</button>
+</div>
+<div id="step4" class="mb-4 hidden">
+  <h2 class="font-bold">4. Review</h2>
+  <table class="min-w-full"><thead><tr><th>Part</th><th>Description</th><th>Qty</th><th>Ref</th></tr></thead><tbody id="bom-table"></tbody></table>
+  <button id="save-bom" class="bg-blue-500 text-white px-2 mt-2">Save BOM</button>
+  <button id="cancel-bom" class="bg-gray-500 text-white px-2 mt-2">Cancel</button>
+</div>
+<script>
+async function loadCustomers(){
+  const r=await fetch('/ui/workflow/customers');
+  const data=await r.json();
+  const sel=document.getElementById('customer-select');
+  sel.innerHTML='<option value="">--select--</option>';
+  data.forEach(c=>{const o=document.createElement('option');o.value=c.id;o.textContent=c.name;sel.appendChild(o);});
+}
+
+document.getElementById('add-customer').onclick=async ()=>{
+  const name=document.getElementById('new-customer-name').value;
+  const contact=document.getElementById('new-customer-contact').value;
+  if(!name) return;
+  await fetch('/ui/workflow/customers',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,contact})});
+  loadCustomers();
+};
+
+document.getElementById('customer-select').onchange=()=>{
+  const cid=document.getElementById('customer-select').value;
+  if(cid){document.getElementById('step2').classList.remove('hidden');loadProjects(cid);}
+};
+
+async function loadProjects(cid){
+  const r=await fetch('/ui/workflow/projects?customer_id='+cid);
+  const data=await r.json();
+  const sel=document.getElementById('project-select');
+  sel.innerHTML='<option value="">--select--</option>';
+  data.forEach(p=>{const o=document.createElement('option');o.value=p.id;o.textContent=p.name;sel.appendChild(o);});
+}
+
+document.getElementById('add-project').onclick=async ()=>{
+  const cid=document.getElementById('customer-select').value;
+  const name=document.getElementById('new-project-name').value;
+  const description=document.getElementById('new-project-desc').value;
+  if(!cid || !name) return;
+  await fetch('/ui/workflow/projects',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({customer_id:cid,name,description})});
+  loadProjects(cid);
+};
+
+document.getElementById('project-select').onchange=()=>{
+  if(document.getElementById('project-select').value){document.getElementById('step3').classList.remove('hidden');}
+};
+
+document.getElementById('upload-bom').onclick=async ()=>{
+  const f=document.getElementById('bom-file').files[0];
+  if(!f) return;
+  const fd=new FormData();fd.append('file',f);
+  const r=await fetch('/ui/workflow/upload',{method:'POST',body:fd});
+  const data=await r.json();
+  const tbody=document.getElementById('bom-table');
+  tbody.innerHTML='';
+  data.forEach(row=>{
+    const tr=document.createElement('tr');
+    ['part_number','description','quantity','reference'].forEach(k=>{
+      const td=document.createElement('td');
+      const inp=document.createElement('input');
+      inp.value=row[k]||''; inp.className='border';
+      if(k==='quantity') inp.type='number';
+      td.appendChild(inp); tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  document.getElementById('step4').classList.remove('hidden');
+};
+
+document.getElementById('save-bom').onclick=async ()=>{
+  const project=document.getElementById('project-select').value;
+  const rows=document.querySelectorAll('#bom-table tr');
+  const items=[];
+  rows.forEach(tr=>{
+    const i=tr.querySelectorAll('input');
+    items.push({part_number:i[0].value,description:i[1].value,quantity:parseInt(i[2].value||1),reference:i[3].value||null});
+  });
+  await fetch('/ui/workflow/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({project_id:parseInt(project),items})});
+  window.location='/ui/workflow/';
+};
+
+document.getElementById('cancel-bom').onclick=()=>{window.location='/ui/workflow/';};
+
+loadCustomers();
+</script>
+{% endblock %}

--- a/app/main.py
+++ b/app/main.py
@@ -22,7 +22,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 import csv
 import io
 import os
-from openpyxl import Workbook
+from openpyxl import Workbook, load_workbook
 
 from .security import verify_password, get_password_hash, create_access_token
 from .config import (
@@ -66,6 +66,8 @@ class BOMItemBase(SQLModel):
     quantity: int = Field(default=1, ge=1)
     reference: str | None = None
 
+    project_id: int | None = Field(default=None, foreign_key="project.id")
+
 
 class BOMItem(BOMItemBase, table=True):
     """Database model for a BOM item."""
@@ -94,6 +96,41 @@ class BOMItemUpdate(SQLModel):
     description: str | None = Field(default=None, min_length=1)
     quantity: int | None = Field(default=None, ge=1)
     reference: str | None = None
+    project_id: int | None = None
+
+
+class Customer(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(sa_column_kwargs={"unique": True})
+    contact: str | None = None
+    active: bool = True
+
+
+class CustomerCreate(SQLModel):
+    name: str
+    contact: str | None = None
+    active: bool = True
+
+
+class CustomerRead(CustomerCreate):
+    id: int
+
+
+class Project(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    customer_id: int = Field(foreign_key="customer.id")
+    name: str
+    description: str | None = None
+
+
+class ProjectCreate(SQLModel):
+    customer_id: int
+    name: str
+    description: str | None = None
+
+
+class ProjectRead(ProjectCreate):
+    id: int
 
 
 class User(SQLModel, table=True):
@@ -260,6 +297,7 @@ def init_db() -> None:
 
 app = FastAPI()
 ui_router = APIRouter(prefix="/ui")
+workflow_router = APIRouter(prefix="/ui/workflow")
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
 
@@ -712,5 +750,111 @@ async def ui_save_settings(request: Request):
     return RedirectResponse("/ui/settings/", status_code=303)
 
 
+# -------- Workflow Endpoints ---------
+
+@workflow_router.get("/", response_class=HTMLResponse)
+def ui_workflow(request: Request):
+    return templates.TemplateResponse(
+        "workflow.html",
+        {"request": request, "title": "Workflow"},
+    )
+
+
+@workflow_router.get("/customers", response_model=list[CustomerRead])
+def wf_customers():
+    with Session(engine) as session:
+        return session.exec(select(Customer).where(Customer.active == True)).all()
+
+
+@workflow_router.post("/customers", response_model=CustomerRead, status_code=status.HTTP_201_CREATED)
+def wf_create_customer(customer: CustomerCreate):
+    with Session(engine) as session:
+        db_cust = Customer.from_orm(customer)
+        session.add(db_cust)
+        try:
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+            raise HTTPException(status_code=409, detail="Customer exists")
+        session.refresh(db_cust)
+        return db_cust
+
+
+@workflow_router.get("/projects", response_model=list[ProjectRead])
+def wf_projects(customer_id: int):
+    with Session(engine) as session:
+        return session.exec(select(Project).where(Project.customer_id == customer_id)).all()
+
+
+@workflow_router.post("/projects", response_model=ProjectRead, status_code=status.HTTP_201_CREATED)
+def wf_create_project(project: ProjectCreate):
+    with Session(engine) as session:
+        db_proj = Project.from_orm(project)
+        session.add(db_proj)
+        session.commit()
+        session.refresh(db_proj)
+        return db_proj
+
+
+class BOMSave(SQLModel):
+    project_id: int
+    items: list[BOMItemCreate]
+
+
+@workflow_router.post("/upload")
+async def wf_upload_bom(file: UploadFile = File(...)):
+    contents = await file.read()
+    ext = file.filename.lower().split(".")[-1]
+    items: list[dict] = []
+    if ext == "csv":
+        text = contents.decode("utf-8", errors="ignore")
+        reader = csv.DictReader(io.StringIO(text))
+        for row in reader:
+            items.append(
+                {
+                    "part_number": row.get("part_number") or row.get("part number") or "",
+                    "description": row.get("description") or row.get("desc") or "",
+                    "quantity": int(row.get("quantity") or row.get("qty") or 1),
+                    "reference": row.get("reference") or row.get("ref") or None,
+                }
+            )
+    elif ext in {"xlsx", "xls"}:
+        wb = load_workbook(io.BytesIO(contents), read_only=True)
+        ws = wb.active
+        headers = [str(c.value).lower() if c.value else "" for c in next(ws.iter_rows(min_row=1, max_row=1))]
+        for row in ws.iter_rows(min_row=2, values_only=True):
+            data = {headers[i]: (row[i] if i < len(row) else None) for i in range(len(headers))}
+            items.append(
+                {
+                    "part_number": data.get("part_number") or data.get("part number") or "",
+                    "description": data.get("description") or data.get("desc") or "",
+                    "quantity": int(data.get("quantity") or data.get("qty") or 1),
+                    "reference": data.get("reference") or data.get("ref") or None,
+                }
+            )
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+    return items
+
+
+@workflow_router.post("/save", response_model=list[BOMItemRead])
+def wf_save_bom(payload: BOMSave):
+    inserted: list[BOMItem] = []
+    with Session(engine) as session:
+        for itm in payload.items:
+            db_item = BOMItem.from_orm(itm)
+            db_item.project_id = payload.project_id
+            session.add(db_item)
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                continue
+            session.refresh(db_item)
+            inserted.append(db_item)
+    return inserted
+
+
 app.include_router(ui_router)
+app.include_router(workflow_router)
 

--- a/tests/test_ui_endpoints.py
+++ b/tests/test_ui_endpoints.py
@@ -6,6 +6,7 @@ client = TestClient(main.app)
 pages = [
     "/ui/",
     "/ui/bom/",
+    "/ui/workflow/",
     "/ui/import/",
     "/ui/quote/",
     "/ui/test/",
@@ -21,6 +22,11 @@ def test_pages_return_html():
         r = client.get(p)
         assert r.status_code == 200
         assert "<title>" in r.text
+
+
+def test_workflow_page_has_wizard():
+    r = client.get("/ui/workflow/")
+    assert "step1" in r.text
 
 
 def test_htmx_create_item():

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,34 @@
+import sqlalchemy
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+
+import app.main as main
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    test_engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = test_engine
+    SQLModel.metadata.create_all(test_engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+def test_customer_project_and_save(client):
+    c = client.post("/ui/workflow/customers", json={"name": "Acme"})
+    assert c.status_code == 201
+    cid = c.json()["id"]
+    plist = client.post("/ui/workflow/projects", json={"customer_id": cid, "name": "Proj"})
+    assert plist.status_code == 201
+    pid = plist.json()["id"]
+    items = [{"part_number": "P1", "description": "A", "quantity": 1}]
+    save = client.post("/ui/workflow/save", json={"project_id": pid, "items": items})
+    assert save.status_code == 200
+    all_items = client.get("/bom/items").json()
+    assert any(i["part_number"] == "P1" for i in all_items)
+


### PR DESCRIPTION
## Summary
- introduce Customer and Project models and related workflow endpoints
- add workflow wizard page to UI and link in navigation
- parse CSV/XLSX uploads and save BOM items for a project
- document the new workflow URL
- test workflow endpoints and UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d8859c80832c8c2e9b05d26c420a