### PR TITLE
Implement workflow CRUD and installer fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,5 @@ chmod +x scripts/setup.sh
 ```
 
 The script creates a virtual environment, installs all optional dependencies and launches the Control Center.
+It now detects the project root and directly invokes the Python inside `.venv`,
+so it works even if `python` isn't on your PATH.

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -1,11 +1,15 @@
 @echo off
-python -m venv .venv
-if exist .venv\Scripts\activate.bat (
-    call .venv\Scripts\activate.bat
-) else (
-    echo Python 3.10+ required
-    exit /b 1
+set ROOT=%~dp0\..
+pushd %ROOT%
+if not exist .venv\Scripts\python.exe (
+    python -m venv .venv || (
+        echo Python 3.10+ required
+        exit /b 1
+    )
 )
-python -m pip install --upgrade pip
-python -m pip install ".[full]"
-python -m gui.control_center
+set PY=%ROOT%\.venv\Scripts\python.exe
+
+%PY% -m pip install --upgrade pip
+%PY% -m pip install ".[full]"
+%PY% -m gui.control_center
+popd

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 set -e
-if ! command -v python3 >/dev/null; then
-  echo "Python 3.10+ required" >&2
-  exit 1
+# Determine project root (one directory up from this script)
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ ! -x ".venv/bin/python" ]; then
+  if command -v python3 >/dev/null; then
+    python3 -m venv .venv
+  else
+    echo "Python 3.10+ required" >&2
+    exit 1
+  fi
 fi
-python3 -m venv .venv
-. .venv/bin/activate
-pip install --upgrade pip
-pip install ".[full]"
-python -m gui.control_center
+
+PY="$(pwd)/.venv/bin/python"
+[ -x "$PY" ] || PY=$(command -v python3)
+
+"$PY" -m pip install --upgrade pip
+"$PY" -m pip install ".[full]"
+"$PY" -m gui.control_center

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -32,3 +32,28 @@ def test_customer_project_and_save(client):
     all_items = client.get("/bom/items").json()
     assert any(i["part_number"] == "P1" for i in all_items)
 
+
+def test_customer_update_delete(client):
+    r = client.post("/ui/workflow/customers", json={"name": "Temp"})
+    cid = r.json()["id"]
+    upd = client.patch(f"/ui/workflow/customers/{cid}", json={"contact": "c"})
+    assert upd.status_code == 200
+    assert upd.json()["contact"] == "c"
+    del_r = client.delete(f"/ui/workflow/customers/{cid}")
+    assert del_r.status_code == 204
+    customers = client.get("/ui/workflow/customers").json()
+    assert all(c["id"] != cid for c in customers)
+
+
+def test_project_update_delete(client):
+    cust = client.post("/ui/workflow/customers", json={"name": "C2"}).json()
+    proj = client.post("/ui/workflow/projects", json={"customer_id": cust["id"], "name": "P"}).json()
+    pid = proj["id"]
+    upd = client.patch(f"/ui/workflow/projects/{pid}", json={"description": "d"})
+    assert upd.status_code == 200
+    assert upd.json()["description"] == "d"
+    del_r = client.delete(f"/ui/workflow/projects/{pid}")
+    assert del_r.status_code == 204
+    projs = client.get("/ui/workflow/projects", params={"customer_id": cust["id"]}).json()
+    assert projs == []
+


### PR DESCRIPTION
## Summary
- rework setup scripts to use the venv's Python and work regardless of PATH
- expose PATCH/DELETE endpoints for customers and projects
- add matching update/delete tests
- document improved installer behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467b9ce35c832cbbcf072695f475b0