### PR TITLE
Improve installer scripts and settings handling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,24 +1,52 @@
-"""Application configuration values."""
+"""Application configuration values and helpers."""
 
 from pathlib import Path
 import os
 import toml
+from sqlmodel import create_engine
+from sqlalchemy.engine import Engine
 
 SETTINGS_PATH = Path.home() / ".bom_platform" / "settings.toml"
+DEFAULT_URL = f"sqlite:///{Path.home() / '.bom_platform' / 'bom_dev.db'}"
 
 BASE_DIR = Path(__file__).resolve().parent
 
 
+def _ensure_settings() -> None:
+    if not SETTINGS_PATH.exists():
+        SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(SETTINGS_PATH, "w") as f:
+            toml.dump({"database": {"url": DEFAULT_URL}}, f)
+
+
 def load_settings() -> str:
     """Return database URL from env or settings.toml."""
+    _ensure_settings()
     url = os.getenv("DATABASE_URL")
     if SETTINGS_PATH.exists():
         data = toml.load(SETTINGS_PATH)
         url = data.get("database", {}).get("url", url)
-    return url or f"sqlite:///{BASE_DIR / 'bom_dev.db'}"
+    return url or DEFAULT_URL
 
 
 DATABASE_URL = load_settings()
+_ENGINE: Engine = create_engine(DATABASE_URL, echo=False)
+
+
+def get_engine(url: str | None = None) -> Engine:
+    """Return engine, recreating if the URL changed."""
+    global _ENGINE, DATABASE_URL
+    new_url = url or load_settings()
+    if new_url != DATABASE_URL:
+        DATABASE_URL = new_url
+        _ENGINE.dispose()
+        _ENGINE = create_engine(DATABASE_URL, echo=False)
+    return _ENGINE
+
+
+def reload_settings() -> None:
+    """Reload settings from disk and rebuild engine if needed."""
+    get_engine(load_settings())
 
 
 def save_database_url(url: str) -> None:

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -1,15 +1,18 @@
 @echo off
-set ROOT=%~dp0\..
-pushd %ROOT%
-if not exist .venv\Scripts\python.exe (
+set "ROOT=%~dp0\.."
+set "PY=%ROOT%\.venv\Scripts\python.exe"
+pushd "%ROOT%"
+if not exist "%PY%" (
     python -m venv .venv || (
         echo Python 3.10+ required
         exit /b 1
     )
 )
-set PY=%ROOT%\.venv\Scripts\python.exe
 
-%PY% -m pip install --upgrade pip
-%PY% -m pip install ".[full]"
+%PY% -m pip install -q --upgrade pip
+%PY% -m pip install -q ".[full]"
 %PY% -m gui.control_center
 popd
+
+echo If PowerShell blocks this script, run:
+echo Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,8 +3,8 @@ set -e
 # Determine project root (one directory up from this script)
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
-
-if [ ! -x ".venv/bin/python" ]; then
+PY="$ROOT/.venv/bin/python"
+if [ ! -x "$PY" ]; then
   if command -v python3 >/dev/null; then
     python3 -m venv .venv
   else
@@ -13,9 +13,6 @@ if [ ! -x ".venv/bin/python" ]; then
   fi
 fi
 
-PY="$(pwd)/.venv/bin/python"
-[ -x "$PY" ] || PY=$(command -v python3)
-
-"$PY" -m pip install --upgrade pip
-"$PY" -m pip install ".[full]"
-"$PY" -m gui.control_center
+"$PY" -m pip install -q --upgrade pip
+"$PY" -m pip install -q ".[full]"
+exec "$PY" -m gui.control_center

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_setup_sh_uses_venv_python(tmp_path):
+    work = tmp_path
+    scripts = work / "scripts"
+    scripts.mkdir()
+    script_src = Path("scripts/setup.sh")
+    script_dest = scripts / "setup.sh"
+    script_dest.write_bytes(script_src.read_bytes())
+
+    vpy = work / ".venv" / "bin" / "python"
+    vpy.parent.mkdir(parents=True)
+    record = work / "called"
+    vpy.write_text(f"#!/bin/sh\necho $0 \"$@\" >> {record}\n")
+    vpy.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = env.get("PATH", "")
+    subprocess.run(["bash", str(script_dest)], cwd=work, env=env, check=True)
+
+    lines = record.read_text().splitlines()
+    assert lines
+    assert all(line.startswith(str(vpy)) for line in lines)
+

--- a/tests/test_reload_db.py
+++ b/tests/test_reload_db.py
@@ -1,0 +1,21 @@
+import importlib
+from pathlib import Path
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.config as config
+
+
+def test_reload_db(tmp_path):
+    cfg = importlib.reload(config)
+    old_engine = cfg.get_engine()
+    old_url = str(old_engine.url)
+    new_url = f"sqlite:///{tmp_path/'new.db'}"
+    cfg.save_database_url(new_url)
+    cfg.reload_settings()
+    new_engine = cfg.get_engine()
+    assert str(new_engine.url) == new_url
+    assert str(old_engine.url) != str(new_engine.url)
+


### PR DESCRIPTION
## Summary
- update installer scripts to always use virtualenv python
- centralize DB settings with helpers in `app.config`
- reload database connection through config helpers
- add settings dialog menu in Control Center GUI
- unit tests for installer and database reload

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852a9403878832c8e9b082125303ca5