### PR TITLE
Implement customer/project workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ curl -F file=@sample.pdf http://localhost:8000/bom/import
 The parser assumes table columns are separated by multiple spaces or tabs. Real
 world PDFs may require tweaks.
 
+### Customers & Projects
+
+Group BOM items by customer and project. Example:
+
+```bash
+curl -X POST http://localhost:8000/customers \
+     -H "Content-Type: application/json" \
+     -d '{"name":"Acme"}'
+curl -X POST http://localhost:8000/projects \
+     -H "Content-Type: application/json" \
+     -d '{"customer_id":1,"name":"Widget"}'
+curl -F file=@sample.csv \
+     http://localhost:8000/bom/import?project_id=1
+```
+
 ### Quote
 
 Get a quick time and cost estimate for the current BOM:
@@ -156,6 +171,7 @@ A new step-by-step workflow is available at `http://localhost:8000/ui/workflow`.
 Switch between SQLite and Postgres under **Configuration**. Saving
 changes rewrites `~/.bom_platform/settings.toml` and reloads the database
 without restarting Python.
+Run `python -m app.migrate` after upgrading to create new tables or columns.
 
 
 ### 📋 Server Control Center GUI

--- a/app/frontend/templates/workflow.html
+++ b/app/frontend/templates/workflow.html
@@ -1,26 +1,26 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="text-2xl mb-4">Customer Workflow</h1>
-<div id="step1" class="mb-4">
+<div id="step-1" class="mb-4">
   <h2 class="font-bold">1. Select Customer</h2>
   <select id="customer-select" class="border"></select>
   <input type="text" id="new-customer-name" placeholder="New customer" class="border" />
   <input type="text" id="new-customer-contact" placeholder="Contact" class="border" />
   <button id="add-customer" class="bg-blue-500 text-white px-2">Add</button>
 </div>
-<div id="step2" class="mb-4 hidden">
+<div id="step-2" class="mb-4 hidden">
   <h2 class="font-bold">2. Select Project</h2>
   <select id="project-select" class="border"></select>
   <input type="text" id="new-project-name" placeholder="New project" class="border" />
   <input type="text" id="new-project-desc" placeholder="Description" class="border" />
   <button id="add-project" class="bg-blue-500 text-white px-2">Add</button>
 </div>
-<div id="step3" class="mb-4 hidden">
+<div id="step-3" class="mb-4 hidden">
   <h2 class="font-bold">3. Upload BOM</h2>
   <input type="file" id="bom-file" accept=".csv,.xlsx" class="border" />
   <button id="upload-bom" class="bg-blue-500 text-white px-2">Upload</button>
 </div>
-<div id="step4" class="mb-4 hidden">
+<div id="step-4" class="mb-4 hidden">
   <h2 class="font-bold">4. Review</h2>
   <table class="min-w-full"><thead><tr><th>Part</th><th>Description</th><th>Qty</th><th>Ref</th></tr></thead><tbody id="bom-table"></tbody></table>
   <button id="save-bom" class="bg-blue-500 text-white px-2 mt-2">Save BOM</button>
@@ -45,7 +45,7 @@ document.getElementById('add-customer').onclick=async ()=>{
 
 document.getElementById('customer-select').onchange=()=>{
   const cid=document.getElementById('customer-select').value;
-  if(cid){document.getElementById('step2').classList.remove('hidden');loadProjects(cid);}
+  if(cid){document.getElementById('step-2').classList.remove('hidden');loadProjects(cid);}
 };
 
 async function loadProjects(cid){
@@ -66,7 +66,7 @@ document.getElementById('add-project').onclick=async ()=>{
 };
 
 document.getElementById('project-select').onchange=()=>{
-  if(document.getElementById('project-select').value){document.getElementById('step3').classList.remove('hidden');}
+  if(document.getElementById('project-select').value){document.getElementById('step-3').classList.remove('hidden');}
 };
 
 document.getElementById('upload-bom').onclick=async ()=>{
@@ -88,7 +88,7 @@ document.getElementById('upload-bom').onclick=async ()=>{
     });
     tbody.appendChild(tr);
   });
-  document.getElementById('step4').classList.remove('hidden');
+  document.getElementById('step-4').classList.remove('hidden');
 };
 
 document.getElementById('save-bom').onclick=async ()=>{

--- a/app/migrate.py
+++ b/app/migrate.py
@@ -1,0 +1,38 @@
+from sqlmodel import SQLModel
+from sqlalchemy import inspect, text
+
+from .config import get_engine
+from . import main  # ensure models are imported
+
+
+def upgrade() -> None:
+    engine = get_engine()
+    insp = inspect(engine)
+    with engine.begin() as conn:
+        if engine.dialect.name == "sqlite":
+            conn.execute(text("PRAGMA foreign_keys=OFF"))
+        SQLModel.metadata.create_all(engine)
+        if "bomitem" in insp.get_table_names():
+            cols = {c["name"] for c in insp.get_columns("bomitem")}
+            if "project_id" not in cols:
+                conn.execute(text("ALTER TABLE bomitem ADD COLUMN project_id INTEGER"))
+        if "customer" in insp.get_table_names():
+            cols = {c["name"] for c in insp.get_columns("customer")}
+            if "notes" not in cols:
+                conn.execute(text("ALTER TABLE customer ADD COLUMN notes TEXT"))
+        if "project" in insp.get_table_names():
+            cols = {c["name"] for c in insp.get_columns("project")}
+            if "code" not in cols:
+                conn.execute(text("ALTER TABLE project ADD COLUMN code VARCHAR"))
+            if "notes" not in cols:
+                conn.execute(text("ALTER TABLE project ADD COLUMN notes TEXT"))
+        if engine.dialect.name == "sqlite":
+            conn.execute(text("PRAGMA foreign_keys=ON"))
+
+
+def main() -> None:
+    upgrade()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_customer_project.py
+++ b/tests/test_customer_project.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import sqlalchemy
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app.main as main
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post(
+        "/auth/token",
+        data={"username": "admin", "password": "change_me"},
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_link_items_to_project(client, auth_header):
+    cust = client.post("/customers", json={"name": "Acme"}).json()
+    proj = client.post(
+        "/projects",
+        json={"customer_id": cust["id"], "name": "Widget"},
+    ).json()
+    import fitz
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "PNX    Part    1    R1")
+    pdf_bytes = doc.tobytes()
+    resp = client.post(
+        f"/bom/import?project_id={proj['id']}",
+        files={"file": ("sample.pdf", pdf_bytes, "application/pdf")},
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    items = client.get("/bom/items").json()
+    assert items[0]["project_id"] == proj["id"]
+    client.delete(f"/customers/{cust['id']}")
+    assert client.get("/bom/items").json() == []
+

--- a/tests/test_ui_endpoints.py
+++ b/tests/test_ui_endpoints.py
@@ -26,7 +26,7 @@ def test_pages_return_html():
 
 def test_workflow_page_has_wizard():
     r = client.get("/ui/workflow/")
-    assert "step1" in r.text
+    assert '<div id="step-1"' in r.text
 
 
 def test_htmx_create_item():

--- a/tests/test_ui_workflow.py
+++ b/tests/test_ui_workflow.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+import app.main as main
+
+client = TestClient(main.app)
+
+def test_workflow_page_contains_step_one():
+    r = client.get("/ui/workflow/")
+    assert r.status_code == 200
+    assert '<div id="step-1"' in r.text
+

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,7 +1,11 @@
 import sqlalchemy
 import pytest
+import os
+import sys
 from fastapi.testclient import TestClient
 from sqlmodel import SQLModel, create_engine
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app.main as main
 
@@ -56,4 +60,5 @@ def test_project_update_delete(client):
     assert del_r.status_code == 204
     projs = client.get("/ui/workflow/projects", params={"customer_id": cust["id"]}).json()
     assert projs == []
+
 


### PR DESCRIPTION
## Summary
- add CRUD API routes for customers and projects
- support project_id in `/bom/import`
- expose migration helper `python -m app.migrate`
- extend workflow page IDs and tests
- create coverage tests for customer/project features
- document new endpoints in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ac6ec2e0832cb43d3a6aa0bc2919