### PR TITLE
Add auth requirement for listing BOM items

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ curl -X DELETE http://localhost:8000/bom/items/1
 
 List items with search and pagination:
 ```bash
-curl "http://localhost:8000/bom/items?search=Cap&min_qty=1&max_qty=10&skip=0&limit=20"
+TOKEN=<token>
+curl -H "Authorization: Bearer $TOKEN" \
+     "http://localhost:8000/bom/items?search=Cap&min_qty=1&max_qty=10&skip=0&limit=20"
 ```
 
 Import a BOM PDF:
@@ -138,6 +140,9 @@ curl -H "Authorization: Bearer $TOKEN" \
      http://localhost:8000/bom/items
 ```
 
+The same token is required when **listing** BOM items or retrieving a
+project's BOM.
+
 ### Traceability
 
 Identify which boards failed because of a component:
@@ -188,7 +193,9 @@ confirmation toast. Uploaded datasheets turn the button into a 📎 link.
 Saved BOM items can be retrieved for further editing:
 
 ```bash
-curl http://localhost:8000/projects/1/bom
+TOKEN=<token>
+curl -H "Authorization: Bearer $TOKEN" \
+     http://localhost:8000/projects/1/bom
 ```
 
 Export the project BOM to CSV:

--- a/app/main.py
+++ b/app/main.py
@@ -610,6 +610,7 @@ def project_bom(
     search: str | None = None,
     skip: int = 0,
     limit: int = 50,
+    current_user: User = Depends(get_current_user),
 ) -> list[BOMItemRead]:
     """List BOM items for a specific project."""
 
@@ -651,6 +652,7 @@ def list_items(
     max_qty: int | None = None,
     skip: int = 0,
     limit: int = 50,
+    current_user: User = Depends(get_current_user),
 ) -> list[BOMItemRead]:
     """Return BOM items with optional filtering and pagination."""
 

--- a/tests/test_bom.py
+++ b/tests/test_bom.py
@@ -53,7 +53,10 @@ def test_list_items(client, auth_header):
     item = {"part_number": "XYZ-1", "description": "Resistor", "quantity": 1}
     client.post("/bom/items", json=item, headers=auth_header)
 
-    response = client.get("/bom/items")
+    unauthorized = client.get("/bom/items")
+    assert unauthorized.status_code == 401
+
+    response = client.get("/bom/items", headers=auth_header)
     assert response.status_code == 200
     data = response.json()
     assert len(data) >= 1

--- a/tests/test_bom_crud.py
+++ b/tests/test_bom_crud.py
@@ -74,14 +74,14 @@ def test_crud_lifecycle(client, auth_header):
 
 def test_list_search_pagination(client, auth_header):
     items = create_sample_items(client, auth_header)
-    resp = client.get("/bom/items", params={"search": "find", "limit": 2})
+    resp = client.get("/bom/items", params={"search": "find", "limit": 2}, headers=auth_header)
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
     assert data[0]["part_number"] == "FINDME"
 
     # pagination
-    resp_all = client.get("/bom/items", params={"skip": 1, "limit": 1})
+    resp_all = client.get("/bom/items", params={"skip": 1, "limit": 1}, headers=auth_header)
     assert resp_all.status_code == 200
     assert len(resp_all.json()) == 1
 

--- a/tests/test_customer_project.py
+++ b/tests/test_customer_project.py
@@ -48,9 +48,9 @@ def test_link_items_to_project(client, auth_header):
         headers=auth_header,
     )
     assert resp.status_code == 200
-    items = client.get("/bom/items").json()
+    items = client.get("/bom/items", headers=auth_header).json()
     assert items[0]["project_id"] == proj["id"]
     assert len(items) > 0
     client.delete(f"/customers/{cust['id']}")
-    assert client.get("/bom/items").json() == []
+    assert client.get("/bom/items", headers=auth_header).json() == []
 

--- a/tests/test_delete_row.py
+++ b/tests/test_delete_row.py
@@ -33,5 +33,5 @@ def test_delete_row(client, auth_header):
     ).json()
     r = client.delete(f"/bom/items/{item['id']}", headers=auth_header)
     assert r.status_code == 204
-    all_items = client.get("/bom/items").json()
+    all_items = client.get("/bom/items", headers=auth_header).json()
     assert all(i["id"] != item["id"] for i in all_items)

--- a/tests/test_get_project_bom.py
+++ b/tests/test_get_project_bom.py
@@ -38,7 +38,10 @@ def test_get_project_bom(client, auth_header):
         json={"part_number": "P2", "description": "D2", "quantity": 2, "project_id": proj["id"]},
         headers=auth_header,
     ).json()
-    r = client.get(f"/projects/{proj['id']}/bom")
+    unauthorized = client.get(f"/projects/{proj['id']}/bom")
+    assert unauthorized.status_code == 401
+
+    r = client.get(f"/projects/{proj['id']}/bom", headers=auth_header)
     assert r.status_code == 200
     data = r.json()
     assert len(data) == 2

--- a/tests/test_pdf_import.py
+++ b/tests/test_pdf_import.py
@@ -57,5 +57,5 @@ def test_import_endpoint(client, auth_header):
     assert len(data) == 1
     assert data[0]["part_number"] == "PN9"
     # ensure item persisted
-    list_resp = client.get("/bom/items")
+    list_resp = client.get("/bom/items", headers=auth_header)
     assert any(i["part_number"] == "PN9" for i in list_resp.json())

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,7 +23,16 @@ def client_fixture():
         yield c
 
 
-def test_customer_project_and_save(client):
+@pytest.fixture
+def auth_header(client):
+    token = client.post(
+        "/auth/token",
+        data={"username": "admin", "password": "change_me"},
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_customer_project_and_save(client, auth_header):
     c = client.post("/ui/workflow/customers", json={"name": "Acme"})
     assert c.status_code == 201
     cid = c.json()["id"]
@@ -33,7 +42,7 @@ def test_customer_project_and_save(client):
     items = [{"part_number": "P1", "description": "A", "quantity": 1}]
     save = client.post("/ui/workflow/save", json={"project_id": pid, "items": items})
     assert save.status_code == 200
-    all_items = client.get("/bom/items").json()
+    all_items = client.get("/bom/items", headers=auth_header).json()
     assert any(i["part_number"] == "P1" for i in all_items)
 
 


### PR DESCRIPTION
## Summary
- require token for `GET /bom/items` and `GET /projects/{id}/bom`
- update docs with authenticated examples
- adjust tests for new auth requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ce6eea1c832ca8a3fbd84303c7c3