### PR TITLE
Workflow 7 updates: richer BOM items, costing, operator role

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Get a quick time and cost estimate for the current BOM:
 ```bash
 curl http://localhost:8000/bom/quote
 ```
+Get total cost for a specific project:
+```bash
+TOKEN=<token>
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/projects/1/cost
+```
 
 ### Test results
 
@@ -111,6 +116,10 @@ curl http://localhost:8000/testresults?skip=0&limit=10
 - **description**: human-friendly description (string, required)
 - **quantity**: number of parts required (integer, min 1, default 1)
 - **reference**: optional reference designator or notes
+- **manufacturer**: optional manufacturer name
+- **mpn**: optional manufacturer part number
+- **footprint**: optional package footprint
+- **unit_cost**: optional unit price (numeric with 4 decimals)
 
 ### Health check
 
@@ -142,6 +151,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 The same token is required when **listing** BOM items or retrieving a
 project's BOM.
+Users with the **operator** role can only view data; any write attempts return 403.
 
 ### Traceability
 

--- a/app/frontend/templates/workflow.html
+++ b/app/frontend/templates/workflow.html
@@ -7,6 +7,11 @@
 </style>
 <script>const MAX_DS_MB={{ max_ds_mb }};</script>
 <h1 class="text-2xl mb-4">Customer Workflow</h1>
+<div id="login" class="mb-4">
+  <input type="text" id="login-user" placeholder="Username" class="border" />
+  <input type="password" id="login-pass" placeholder="Password" class="border" />
+  <button id="login-btn" class="bg-blue-500 text-white px-2">Login</button>
+</div>
 <div id="step-1" class="mb-4">
   <h2 class="font-bold">1. Select Customer</h2>
   <select id="customer-select" class="border"></select>
@@ -28,7 +33,7 @@
 </div>
 <div id="step-4" class="mb-4 hidden">
   <h2 class="font-bold">4. Review</h2>
-  <table class="min-w-full"><thead><tr><th>Part</th><th>Description</th><th>Qty</th><th>Ref</th><th>DS</th></tr></thead><tbody id="bom-table"></tbody></table>
+  <table class="min-w-full"><thead><tr><th>Part</th><th>Description</th><th>Qty</th><th>Ref</th><th>Mfr</th><th>MPN</th><th>Footprint</th><th>Unit$</th><th>DS</th><th></th></tr></thead><tbody id="bom-table"></tbody></table>
   <div id="pagination" class="mt-2 flex items-center space-x-2">
     <button id="prev-page" class="border px-2">Prev</button>
     <span id="page-info"></span>
@@ -36,14 +41,33 @@
     <input id="page-jump" type="number" class="border w-16" />
     <button id="go-page" class="border px-2">Go</button>
   </div>
+  <div id="cost-bar" class="mt-1"></div>
+  <datalist id="mfr-suggest"></datalist>
+  <datalist id="mpn-suggest"></datalist>
   <div id="toast" class="fixed bottom-4 right-4 hidden bg-green-600 text-white px-2 py-1 rounded">Saved!</div>
   <button id="save-bom" class="bg-blue-500 text-white px-2 mt-2">Save BOM</button>
   <button id="cancel-bom" class="bg-gray-500 text-white px-2 mt-2">Cancel</button>
   <button id="export-csv" class="bg-blue-500 text-white px-2 mt-2">Export CSV</button>
 </div>
 <script>
+function authFetch(url, opts={}){
+  opts.headers=opts.headers||{};
+  const t=sessionStorage.getItem('token');
+  if(t) opts.headers['Authorization']='Bearer '+t;
+  return fetch(url, opts);
+}
+document.getElementById('login-btn').onclick=async()=>{
+  const u=document.getElementById('login-user').value;
+  const p=document.getElementById('login-pass').value;
+  const r=await fetch('/auth/token',{method:'POST',body:new URLSearchParams({username:u,password:p})});
+  if(r.ok){
+    const tok=(await r.json()).access_token;
+    sessionStorage.setItem('token',tok);
+    document.getElementById('login').classList.add('hidden');
+  }else{alert('Login failed');}
+};
 async function loadCustomers(){
-  const r=await fetch('/ui/workflow/customers');
+  const r=await authFetch('/ui/workflow/customers');
   const data=await r.json();
   const sel=document.getElementById('customer-select');
   sel.innerHTML='<option value="">--select--</option>';
@@ -54,7 +78,7 @@ document.getElementById('add-customer').onclick=async ()=>{
   const name=document.getElementById('new-customer-name').value;
   const contact=document.getElementById('new-customer-contact').value;
   if(!name) return;
-  await fetch('/ui/workflow/customers',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,contact})});
+  await authFetch('/ui/workflow/customers',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,contact})});
   loadCustomers();
 };
 
@@ -64,7 +88,7 @@ document.getElementById('customer-select').onchange=()=>{
 };
 
 async function loadProjects(cid){
-  const r=await fetch('/ui/workflow/projects?customer_id='+cid);
+  const r=await authFetch('/ui/workflow/projects?customer_id='+cid);
   const data=await r.json();
   const sel=document.getElementById('project-select');
   sel.innerHTML='<option value="">--select--</option>';
@@ -76,15 +100,16 @@ document.getElementById('add-project').onclick=async ()=>{
   const name=document.getElementById('new-project-name').value;
   const description=document.getElementById('new-project-desc').value;
   if(!cid || !name) return;
-  await fetch('/ui/workflow/projects',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({customer_id:cid,name,description})});
+  await authFetch('/ui/workflow/projects',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({customer_id:cid,name,description})});
   loadProjects(cid);
 };
 document.getElementById("project-select").onchange=async()=>{
   const pid=document.getElementById("project-select").value;
   if(!pid) return;
   document.getElementById("step-3").classList.remove("hidden");
-  const r=await fetch(`/projects/${pid}/bom?limit=1000`);
+  const r=await authFetch(`/projects/${pid}/bom?limit=1000`);
   const data=await r.json();
+  updateCost();
   if(data.length && confirm("Edit existing BOM?")){
     items=data;
     page=0;
@@ -104,6 +129,28 @@ function showToast(msg="Saved!", ok=true){
   t.classList.remove("hidden");
   setTimeout(()=>t.classList.add("hidden"),1500);
 }
+async function updateCost(){
+  const pid=document.getElementById('project-select').value;
+  if(!pid) return;
+  const r=await authFetch(`/projects/${pid}/cost`);
+  if(r.ok){const d=await r.json();document.getElementById('cost-bar').textContent=`Est. cost $${d.total_cost}`;} }
+
+let acTimer;
+function autocomplete(field,q){
+  clearTimeout(acTimer);
+  const pid=document.getElementById('project-select').value;
+  if(!pid||!q){return;}
+  acTimer=setTimeout(async()=>{
+    const r=await authFetch(`/projects/${pid}/bom?search=${encodeURIComponent(q)}`);
+    if(r.ok){
+      const data=await r.json();
+      const opts=[...new Set(data.map(it=>it[field]).filter(Boolean))].slice(0,5);
+      const list=document.getElementById(field==='manufacturer'?'mfr-suggest':'mpn-suggest');
+      list.innerHTML='';
+      opts.forEach(v=>{const o=document.createElement('option');o.value=v;list.appendChild(o);});
+    }
+  },300);
+}
 function triggerUpload(id,idx){
   const input=document.createElement('input');
   input.type='file';
@@ -111,7 +158,7 @@ function triggerUpload(id,idx){
     const f=input.files[0];
     if(!f) return;
     const fd=new FormData();fd.append('file',f);
-    const r=await fetch(`/bom/items/${id}/datasheet`,{method:'POST',body:fd});
+    const r=await authFetch(`/bom/items/${id}/datasheet`,{method:'POST',body:fd});
     if(r.ok){
       items[idx]=await r.json();
       showToast();
@@ -129,8 +176,10 @@ async function patchField(idx,field,value){
   const item=items[idx];
   if(!item.id){item[field]=value;return;}
   const body={};
-  body[field]=field==="quantity"?parseInt(value,10)||1:value||null;
-  const r=await fetch(`/bom/items/${item.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+  if(field==="quantity") body[field]=parseInt(value,10)||1;
+  else if(field==="unit_cost") body[field]=value?parseFloat(value):null;
+  else body[field]=value||null;
+  const r=await authFetch(`/bom/items/${item.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
   if(r.ok){
     items[idx]=await r.json();
     showToast();
@@ -141,7 +190,7 @@ async function patchField(idx,field,value){
 async function deleteRow(idx){
   const item=items[idx];
   if(item.id){
-    const r=await fetch(`/bom/items/${item.id}`,{method:"DELETE"});
+    const r=await authFetch(`/bom/items/${item.id}`,{method:"DELETE"});
     if(r.status!==204){
       showToast("Error",false);
       return;
@@ -163,11 +212,14 @@ function renderPage(){
   slice.forEach((row,idx)=>{
     const realIdx=page*pageSize+idx;
     const tr=document.createElement('tr');
-    ['part_number','description','quantity','reference'].forEach(k=>{
+    ['part_number','description','quantity','reference','manufacturer','mpn','footprint','unit_cost'].forEach(k=>{
       const td=document.createElement('td');
       const inp=document.createElement('input');
       inp.value=row[k]||'';inp.className='border w-full';
       if(k==='quantity') inp.type='number';
+      if(k==='unit_cost') inp.type='number';
+      if(k==='manufacturer'){inp.setAttribute('list','mfr-suggest');inp.oninput=()=>autocomplete('manufacturer',inp.value);}
+      if(k==='mpn'){inp.setAttribute('list','mpn-suggest');inp.oninput=()=>autocomplete('mpn',inp.value);}
       inp.onblur=()=>patchField(realIdx,k,inp.value);
       td.appendChild(inp);tr.appendChild(td);
     const td=document.createElement('td');
@@ -198,13 +250,14 @@ function renderPage(){
   document.getElementById('next-page').disabled=page>=pages-1;
   const pdiv=document.getElementById('pagination');
   if(pages<=1){pdiv.classList.add('hidden');}else{pdiv.classList.remove('hidden');}
+  updateCost();
 }
 
 document.getElementById('upload-bom').onclick=async ()=>{
   const f=document.getElementById('bom-file').files[0];
   if(!f) return;
   const fd=new FormData();fd.append('file',f);
-  const r=await fetch('/ui/workflow/upload',{method:'POST',body:fd});
+  const r=await authFetch('/ui/workflow/upload',{method:'POST',body:fd});
   const data=await r.json();
   items=data;
   page=0;
@@ -229,13 +282,23 @@ document.getElementById('save-bom').onclick=async ()=>{
   const payload=[];
   rows.forEach(tr=>{
     const i=tr.querySelectorAll('input');
-    payload.push({part_number:i[0].value,description:i[1].value,quantity:parseInt(i[2].value,10)||1,reference:i[3].value||null});
+    payload.push({
+      part_number:i[0].value,
+      description:i[1].value,
+      quantity:parseInt(i[2].value,10)||1,
+      reference:i[3].value||null,
+      manufacturer:i[4].value||null,
+      mpn:i[5].value||null,
+      footprint:i[6].value||null,
+      unit_cost:i[7].value?parseFloat(i[7].value):null
+    });
   });
-  const resp=await fetch('/ui/workflow/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({project_id:parseInt(project),items:payload})});
+  const resp=await authFetch('/ui/workflow/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({project_id:parseInt(project),items:payload})});
   if(resp.ok){
     items=await resp.json();
     renderPage();
     showToast();
+    updateCost();
   }
 };
 
@@ -243,7 +306,7 @@ document.getElementById('cancel-bom').onclick=()=>{window.location='/ui/workflow
 document.getElementById('export-csv').onclick=async()=>{
   const pid=document.getElementById('project-select').value;
   if(!pid) return;
-  const r=await fetch(`/projects/${pid}/export.csv`);
+  const r=await authFetch(`/projects/${pid}/export.csv`);
   const blob=await r.blob();
   const url=URL.createObjectURL(blob);
   const a=document.createElement('a');

--- a/app/migrate.py
+++ b/app/migrate.py
@@ -18,6 +18,17 @@ def upgrade() -> None:
                 conn.execute(text("ALTER TABLE bomitem ADD COLUMN project_id INTEGER"))
             if "datasheet_url" not in cols:
                 conn.execute(text("ALTER TABLE bomitem ADD COLUMN datasheet_url TEXT"))
+            if "manufacturer" not in cols:
+                conn.execute(text("ALTER TABLE bomitem ADD COLUMN manufacturer TEXT"))
+            if "mpn" not in cols:
+                conn.execute(text("ALTER TABLE bomitem ADD COLUMN mpn TEXT"))
+            if "footprint" not in cols:
+                conn.execute(text("ALTER TABLE bomitem ADD COLUMN footprint TEXT"))
+            if "unit_cost" not in cols:
+                if engine.dialect.name == "sqlite":
+                    conn.execute(text("ALTER TABLE bomitem ADD COLUMN unit_cost NUMERIC"))
+                else:
+                    conn.execute(text("ALTER TABLE bomitem ADD COLUMN IF NOT EXISTS unit_cost NUMERIC(10,4)"))
             if engine.dialect.name == "postgresql":
                 conn.execute(text("ALTER TABLE bomitem DROP CONSTRAINT IF EXISTS bomitem_project_id_fkey"))
                 conn.execute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ full = [
     "passlib[bcrypt]",
     "PyJWT",
     "openpyxl",
+    "xlrd",
     "apscheduler",
     "requests",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ python-multipart
 passlib[bcrypt]
 PyJWT
 openpyxl
+xlrd
 apscheduler
 requests
 jinja2

--- a/tests/test_cost_endpoint.py
+++ b/tests/test_cost_endpoint.py
@@ -1,0 +1,26 @@
+import sqlalchemy, pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import app.main as main
+
+@pytest.fixture(name='client')
+def client_fixture():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False}, poolclass=sqlalchemy.pool.StaticPool)
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post('/auth/token', data={'username':'admin','password':'change_me'}).json()['access_token']
+    return {'Authorization': f'Bearer {token}'}
+
+def test_project_cost(client, auth_header):
+    cust = client.post('/customers', json={'name':'C'}).json()
+    proj = client.post('/projects', json={'customer_id':cust['id'], 'name':'P'}).json()
+    client.post('/bom/items', json={'part_number':'A','description':'d','quantity':2,'unit_cost':0.5,'project_id':proj['id']}, headers=auth_header)
+    client.post('/bom/items', json={'part_number':'B','description':'d','quantity':3,'unit_cost':1,'project_id':proj['id']}, headers=auth_header)
+    r = client.get(f"/projects/{proj['id']}/cost", headers=auth_header)
+    assert r.status_code == 200
+    assert r.json()['total_cost'] == pytest.approx(2*0.5+3*1, rel=1e-2)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,13 @@
+import sqlalchemy
+from sqlmodel import create_engine
+import app.main as main
+
+def test_migration_adds_new_columns(tmp_path):
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False}, poolclass=sqlalchemy.pool.StaticPool)
+    main.engine = engine
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text('CREATE TABLE bomitem (id INTEGER PRIMARY KEY, part_number TEXT, description TEXT, quantity INTEGER, reference TEXT)'))
+    main.migrate_db()
+    insp = sqlalchemy.inspect(engine)
+    cols = {c['name'] for c in insp.get_columns('bomitem')}
+    assert {'manufacturer','mpn','footprint','unit_cost'}.issubset(cols)

--- a/tests/test_operator_role.py
+++ b/tests/test_operator_role.py
@@ -1,0 +1,26 @@
+import sqlalchemy
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import app.main as main
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False}, poolclass=sqlalchemy.pool.StaticPool)
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+@pytest.fixture
+def admin_header(client):
+    token = client.post('/auth/token', data={'username':'admin','password':'change_me'}).json()['access_token']
+    return {'Authorization': f'Bearer {token}'}
+
+def test_operator_cannot_patch(client, admin_header):
+    client.post('/auth/register', json={'username':'op','password':'pw','role':'operator'}, headers=admin_header)
+    op_token = client.post('/auth/token', data={'username':'op','password':'pw'}).json()['access_token']
+    op_header = {'Authorization': f'Bearer {op_token}'}
+    item = client.post('/bom/items', json={'part_number':'P1','description':'d','quantity':1}, headers=admin_header).json()
+    r = client.patch(f"/bom/items/{item['id']}", json={'quantity':2}, headers=op_header)
+    assert r.status_code == 403

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -50,18 +50,19 @@ def test_calculate_quote():
 def test_quote_endpoint(client, auth_header):
     client.post(
         "/bom/items",
-        json={"part_number": "P1", "description": "A", "quantity": 2},
+        json={"part_number": "P1", "description": "A", "quantity": 2, "unit_cost": 0.5},
         headers=auth_header,
     )
     client.post(
         "/bom/items",
-        json={"part_number": "P2", "description": "B", "quantity": 3},
+        json={"part_number": "P2", "description": "B", "quantity": 3, "unit_cost": 1.0},
         headers=auth_header,
     )
     resp = client.get("/bom/quote")
     assert resp.status_code == 200
     data = resp.json()
-    assert set(data.keys()) == {"total_components", "estimated_time_s", "estimated_cost_usd"}
+    assert set(data.keys()) == {"total_components", "estimated_time_s", "estimated_cost_usd", "total_cost"}
     assert data["total_components"] == 5
     assert isinstance(data["estimated_time_s"], int)
     assert isinstance(data["estimated_cost_usd"], float)
+    assert data["total_cost"] == pytest.approx(2*0.5 + 3*1.0, rel=1e-2)


### PR DESCRIPTION
## Summary
- extend `BOMItem` model with manufacturer, mpn, footprint and unit_cost
- add `edit_allowed` dependency and new operator role
- compute BOM and project costing with new `/projects/{id}/cost` endpoint
- enhance `/bom/quote` with `total_cost`
- support Excel import for BOMs
- token-aware workflow UI with extra columns and live cost bar
- new tests for migrations, operator role and costing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a28415e0832c987e4293c0482389