### PR TITLE
Workflow step 8 additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ curl -H "Authorization: Bearer $TOKEN" \
      "http://localhost:8000/bom/items?search=Cap&min_qty=1&max_qty=10&skip=0&limit=20"
 ```
 
-Import a BOM PDF:
+Import a BOM file:
 ```bash
 curl -F file=@sample.pdf http://localhost:8000/bom/import
+curl -F file=@bom.csv http://localhost:8000/bom/import
 ```
-The parser assumes table columns are separated by multiple spaces or tabs. Real
-world PDFs may require tweaks.
+CSV columns may include `manufacturer`, `mpn`, `footprint` and `unit_cost`.
 
 ### Customers & Projects
 
@@ -89,11 +89,12 @@ Get a quick time and cost estimate for the current BOM:
 ```bash
 curl http://localhost:8000/bom/quote
 ```
-Get total cost for a specific project:
+Get a quote for a specific project:
 ```bash
 TOKEN=<token>
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/projects/1/cost
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/projects/1/quote
 ```
+Labor cost is calculated using `BOM_HOURLY_USD` (default `$25/hr`).
 
 ### Test results
 

--- a/app/config.py
+++ b/app/config.py
@@ -61,3 +61,6 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 # Max allowed datasheet upload size in megabytes
 MAX_DATASHEET_MB = int(os.getenv("BOM_MAX_DS_MB", 10))
+
+# Hourly assembly cost used for quotes
+BOM_HOURLY_USD = float(os.getenv("BOM_HOURLY_USD", 25))

--- a/app/frontend/templates/base.html
+++ b/app/frontend/templates/base.html
@@ -5,6 +5,27 @@
     <title>{{ title }}</title>
     <script src="https://unpkg.com/htmx.org@1.9.2"></script>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet">
+    <script>
+    function authFetch(url, opts={}){
+        opts.headers = opts.headers || {};
+        const t = sessionStorage.getItem('token');
+        if(t) opts.headers['Authorization'] = 'Bearer '+t;
+        return fetch(url, opts);
+    }
+    async function checkOperator(){
+        const t = sessionStorage.getItem('token');
+        if(!t) return;
+        const r = await authFetch('/auth/me');
+        if(r.ok){
+            const u = await r.json();
+            if(u.role === 'operator'){
+                document.querySelectorAll('input').forEach(el=>el.disabled=true);
+                document.querySelectorAll('#save-bom,.del-btn,#upload-bom,#import-btn,.upload-btn').forEach(el=>el && el.classList.add('hidden'));
+            }
+        }
+    }
+    window.addEventListener('load', checkOperator);
+    </script>
 </head>
 <body class="p-4">
     <nav class="mb-4">

--- a/app/frontend/templates/import.html
+++ b/app/frontend/templates/import.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="text-2xl mb-4">Import PDF</h1>
+<h1 class="text-2xl mb-4">Import BOM</h1>
 <form hx-post="/bom/import" enctype="multipart/form-data" class="space-y-2">
-  <input type="file" name="file" accept="application/pdf" required>
-  <button type="submit" class="bg-blue-500 text-white px-2">Upload</button>
+  <input type="file" name="file" accept=".pdf,.csv,.xlsx" required>
+  <button id="import-btn" type="submit" class="bg-blue-500 text-white px-2">Upload</button>
 </form>
 {% endblock %}

--- a/app/frontend/templates/workflow.html
+++ b/app/frontend/templates/workflow.html
@@ -5,7 +5,7 @@
   #toast{bottom:6rem;}
 }
 </style>
-<script>const MAX_DS_MB={{ max_ds_mb }};</script>
+<script>const MAX_DS_MB={{ max_ds_mb }};const HOURLY={{ hourly }};</script>
 <h1 class="text-2xl mb-4">Customer Workflow</h1>
 <div id="login" class="mb-4">
   <input type="text" id="login-user" placeholder="Username" class="border" />
@@ -33,7 +33,7 @@
 </div>
 <div id="step-4" class="mb-4 hidden">
   <h2 class="font-bold">4. Review</h2>
-  <table class="min-w-full"><thead><tr><th>Part</th><th>Description</th><th>Qty</th><th>Ref</th><th>Mfr</th><th>MPN</th><th>Footprint</th><th>Unit$</th><th>DS</th><th></th></tr></thead><tbody id="bom-table"></tbody></table>
+  <table class="min-w-full"><thead><tr><th>Part</th><th>Description</th><th>Qty</th><th>Ref</th><th>Mfr</th><th>MPN</th><th>Footprint</th><th>Unit$</th><th>Total $</th><th>DS</th><th></th></tr></thead><tbody id="bom-table"></tbody></table>
   <div id="pagination" class="mt-2 flex items-center space-x-2">
     <button id="prev-page" class="border px-2">Prev</button>
     <span id="page-info"></span>
@@ -50,12 +50,7 @@
   <button id="export-csv" class="bg-blue-500 text-white px-2 mt-2">Export CSV</button>
 </div>
 <script>
-function authFetch(url, opts={}){
-  opts.headers=opts.headers||{};
-  const t=sessionStorage.getItem('token');
-  if(t) opts.headers['Authorization']='Bearer '+t;
-  return fetch(url, opts);
-}
+const usd=new Intl.NumberFormat('en-US',{style:'currency',currency:'USD'});
 document.getElementById('login-btn').onclick=async()=>{
   const u=document.getElementById('login-user').value;
   const p=document.getElementById('login-pass').value;
@@ -64,6 +59,7 @@ document.getElementById('login-btn').onclick=async()=>{
     const tok=(await r.json()).access_token;
     sessionStorage.setItem('token',tok);
     document.getElementById('login').classList.add('hidden');
+    checkOperator();
   }else{alert('Login failed');}
 };
 async function loadCustomers(){
@@ -132,8 +128,16 @@ function showToast(msg="Saved!", ok=true){
 async function updateCost(){
   const pid=document.getElementById('project-select').value;
   if(!pid) return;
-  const r=await authFetch(`/projects/${pid}/cost`);
-  if(r.ok){const d=await r.json();document.getElementById('cost-bar').textContent=`Est. cost $${d.total_cost}`;} }
+  const r=await authFetch(`/projects/${pid}/quote`);
+  if(r.ok){
+    const d=await r.json();
+    const parts=d.total_cost||0;
+    const labor=d.estimated_time_s/3600*HOURLY;
+    const total=parts+labor;
+    const qty=d.total_components;
+    document.getElementById('cost-bar').textContent=`Components ${items.length} \u2022 Qty ${qty} \u2022 Parts ${usd.format(parts)} \u2022 Labor ${usd.format(labor)} \u2022 Total ${usd.format(total)}`;
+  }
+ }
 
 let acTimer;
 function autocomplete(field,q){
@@ -174,7 +178,14 @@ function triggerUpload(id,idx){
 
 async function patchField(idx,field,value){
   const item=items[idx];
-  if(!item.id){item[field]=value;return;}
+  if(!item.id){
+    if(field==='quantity') item[field]=parseInt(value,10)||1;
+    else if(field==='unit_cost') item[field]=value?parseFloat(value):null;
+    else item[field]=value||null;
+    renderPage();
+    updateCost();
+    return;
+  }
   const body={};
   if(field==="quantity") body[field]=parseInt(value,10)||1;
   else if(field==="unit_cost") body[field]=value?parseFloat(value):null;
@@ -183,6 +194,8 @@ async function patchField(idx,field,value){
   if(r.ok){
     items[idx]=await r.json();
     showToast();
+    renderPage();
+    updateCost();
   }else{
     showToast("Error",false);
   }
@@ -200,6 +213,7 @@ async function deleteRow(idx){
   if(page>0 && page*pageSize>=items.length) page--;
   renderPage();
   showToast("Deleted");
+  updateCost();
 }
 
 
@@ -222,6 +236,12 @@ function renderPage(){
       if(k==='mpn'){inp.setAttribute('list','mpn-suggest');inp.oninput=()=>autocomplete('mpn',inp.value);}
       inp.onblur=()=>patchField(realIdx,k,inp.value);
       td.appendChild(inp);tr.appendChild(td);
+      if(k==='unit_cost'){
+        const ttd=document.createElement('td');
+        ttd.textContent=usd.format((row.unit_cost||0)*row.quantity);
+        tr.appendChild(ttd);
+      }
+    });
     const td=document.createElement('td');
     if(row.datasheet_url){
       const a=document.createElement('a');
@@ -233,6 +253,7 @@ function renderPage(){
       const btn=document.createElement('button');
       btn.textContent='Upload';
       btn.id=`upload-ds-btn-${realIdx}`;
+      btn.className='upload-btn';
       btn.onclick=()=>triggerUpload(row.id,realIdx);
       td.appendChild(btn);
     }
@@ -240,6 +261,7 @@ function renderPage(){
     const deltd=document.createElement("td");
     const delbtn=document.createElement("button");
     delbtn.textContent="🗑";
+    delbtn.className='del-btn';
     delbtn.onclick=()=>deleteRow(realIdx);
     deltd.appendChild(delbtn);
     tr.appendChild(deltd);
@@ -316,6 +338,7 @@ document.getElementById('export-csv').onclick=async()=>{
   URL.revokeObjectURL(url);
 };
 
+checkOperator();
 loadCustomers();
 </script>
 {% endblock %}

--- a/tests/test_csv_import.py
+++ b/tests/test_csv_import.py
@@ -1,0 +1,26 @@
+import sqlalchemy
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import app.main as main
+import pytest
+
+@pytest.fixture(name='client')
+def client_fixture():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False}, poolclass=sqlalchemy.pool.StaticPool)
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post('/auth/token', data={'username':'admin','password':'change_me'}).json()['access_token']
+    return {'Authorization': f'Bearer {token}'}
+
+def test_semicolon_csv_import(client, auth_header):
+    data = 'part_number;description;quantity;unit_cost\nP1;Res;2;1.5\n'
+    files = {'file': ('bom.csv', data, 'text/csv')}
+    r = client.post('/bom/import', files=files, headers=auth_header)
+    assert r.status_code == 200
+    item = r.json()[0]
+    assert item['unit_cost'] == 1.5

--- a/tests/test_operator_ui.py
+++ b/tests/test_operator_ui.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+import app.main as main
+
+client = TestClient(main.app)
+
+def test_operator_ui_contains_role_script():
+    r = client.get('/ui/workflow/')
+    assert '/auth/me' in r.text
+    assert 'checkOperator' in r.text

--- a/tests/test_project_quote.py
+++ b/tests/test_project_quote.py
@@ -1,0 +1,28 @@
+import sqlalchemy, pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import app.main as main
+
+@pytest.fixture(name='client')
+def client_fixture():
+    engine = create_engine('sqlite:///:memory:', connect_args={'check_same_thread': False}, poolclass=sqlalchemy.pool.StaticPool)
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post('/auth/token', data={'username':'admin','password':'change_me'}).json()['access_token']
+    return {'Authorization': f'Bearer {token}'}
+
+def test_project_quote_endpoint(client, auth_header):
+    cust = client.post('/customers', json={'name':'C'}).json()
+    proj = client.post('/projects', json={'customer_id':cust['id'], 'name':'P'}).json()
+    client.post('/bom/items', json={'part_number':'A','description':'d','quantity':2,'unit_cost':0.5,'project_id':proj['id']}, headers=auth_header)
+    client.post('/bom/items', json={'part_number':'B','description':'d','quantity':3,'unit_cost':1,'project_id':proj['id']}, headers=auth_header)
+    r = client.get(f"/projects/{proj['id']}/quote", headers=auth_header)
+    assert r.status_code == 200
+    d = r.json()
+    assert d['total_components'] == 5
+    assert d['total_cost'] == pytest.approx(2*0.5+3*1, rel=1e-2)


### PR DESCRIPTION
## Summary
- add per-project quote endpoint and auth/me helper
- support CSV import with new BOM fields
- integrate operator read-only mode into UI
- show BOM cost summary in workflow with live updates
- track hourly rate via `BOM_HOURLY_USD`
- update docs and add tests for quote math and CSV import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a5d94184832c80e243d6dbb63932