### PR TITLE
Add unified blob storage with upload endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ The datasheet upload size limit defaults to 10 MB. Set `BOM_MAX_DS_MB` to
 override this cap.
 `FX_CACHE_HOURS` controls how long exchange rates are cached (default 24).
 
+### Test Assets
+
+Upload       Endpoint                       Accepted/limit
+-----------  -----------------------------  ----------------------
+3-D Model    POST /testmacros/{id}/upload_glb    .glb ≤ 10 MB
+EDA Bundle   POST /complexes/{id}/upload_eda     .zip ≤ 20 MB
+Python Test  POST /pythontests/{id}/upload_file  .py ≤ 1 MB
+
+Download files via `/assets/{sha}/{name}`.
+
 Workflow inline editing with the clip icon is shown in the documentation.
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -62,6 +62,11 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 30
 # Max allowed datasheet upload size in megabytes
 MAX_DATASHEET_MB = int(os.getenv("BOM_MAX_DS_MB", 10))
 
+# Max upload sizes for test assets
+MAX_GLB_MB = int(os.getenv("BOM_MAX_GLB_MB", 10))
+MAX_EDA_MB = int(os.getenv("BOM_MAX_EDA_MB", 20))
+MAX_PY_MB = int(os.getenv("BOM_MAX_PY_MB", 1))
+
 # Hourly assembly cost used for quotes
 BOM_HOURLY_USD = float(os.getenv("BOM_HOURLY_USD", 25))
 

--- a/migrations/versions/0004_blob_sizes.py
+++ b/migrations/versions/0004_blob_sizes.py
@@ -1,0 +1,21 @@
+from alembic import op
+import sqlalchemy as sa
+import os
+from pathlib import Path
+
+def upgrade():
+    conn = op.get_bind()
+    if 'size' not in [c['name'] for c in sa.inspect(conn).get_columns('blob')]:
+        op.add_column('blob', sa.Column('size', sa.Integer))
+    res = conn.execute(sa.text('SELECT sha256 FROM blob')).fetchall()
+    for (sha,) in res:
+        prefix = sha[:2]
+        glob_path = Path('assets') / prefix
+        for fname in glob_path.glob(f'{sha}.*'):
+            conn.execute(sa.text('UPDATE blob SET size=:s WHERE sha256=:h'), {'s': fname.stat().st_size, 'h': sha})
+            break
+    op.create_index('ix_blob_size', 'blob', ['size'])
+
+def downgrade():
+    op.drop_index('ix_blob_size', table_name='blob')
+    op.drop_column('blob', 'size')

--- a/migrations/versions/0004_stub.py
+++ b/migrations/versions/0004_stub.py
@@ -1,9 +1,0 @@
-# placeholder for milestone 4
-from alembic import op
-import sqlalchemy as sa
-
-def upgrade():
-    pass
-
-def downgrade():
-    pass

--- a/tests/test_asset_uploads.py
+++ b/tests/test_asset_uploads.py
@@ -1,0 +1,53 @@
+import os, sys, sqlalchemy, pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app.main as main
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post("/auth/token", data={"username": "admin", "password": "change_me"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_upload_and_cleanup(client, auth_header):
+    macro = client.post("/testmacros", json={"name": "M"}, headers=auth_header).json()
+    data = b"dummy"
+    r = client.post(
+        f"/testmacros/{macro['id']}/upload_glb",
+        files={"file": ("m.glb", data, "model/gltf-binary")},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    glb_path = r.json()["glb_path"]
+    assert glb_path.startswith("assets/")
+    assert os.path.exists(glb_path)
+    sha = os.path.basename(glb_path).split(".")[0]
+    with main.Session(main.engine) as session:
+        assert session.get(main.Blob, sha) is not None
+
+    macro2 = client.post("/testmacros", json={"name": "N"}, headers=auth_header).json()
+    r2 = client.post(
+        f"/testmacros/{macro2['id']}/upload_glb",
+        files={"file": ("m.glb", data, "model/gltf-binary")},
+        headers=auth_header,
+    )
+    assert r2.status_code == 200
+
+    client.delete(f"/testmacros/{macro['id']}", headers=auth_header)
+    assert os.path.exists(glb_path)
+    client.delete(f"/testmacros/{macro2['id']}", headers=auth_header)
+    assert not os.path.exists(glb_path)


### PR DESCRIPTION
## Summary
- implement blob storage helper and cleanup logic
- add GLB/EDA/Python upload endpoints and download route
- include new migration for blob sizes and index
- update README with Test Assets section
- tests for asset uploads and orphan file cleanup

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fcb7187f0832c8f6e1be4e2eb845b