### PR TITLE
Implement Test Assets GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ Python Test  POST /pythontests/{id}/upload_file  .py ≤ 1 MB
 
 Download files via `/assets/{sha}/{name}`.
 
+
+Example:
+```bash
+curl http://localhost:8000/ui/testassets/table
+```
+
 Workflow inline editing with the clip icon is shown in the documentation.
 
 

--- a/app/frontend/templates/base.html
+++ b/app/frontend/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>{{ title }}</title>
     <script src="https://unpkg.com/htmx.org@1.9.2"></script>
+    <script src="https://unpkg.com/@google/model-viewer"></script>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet">
     <script>
     function authFetch(url, opts={}){

--- a/app/frontend/templates/testasset_detail.html
+++ b/app/frontend/templates/testasset_detail.html
@@ -1,0 +1,20 @@
+<div id="drawer" class="p-4 border">
+  <h2 class="text-xl mb-2">{{ macro.name }}</h2>
+  <p>ID: {{ macro.id }}</p>
+  {% if macro.glb_path %}
+  <model-viewer src="/{{ macro.glb_path }}" alt="{{ macro.name }}" camera-controls ar style="width:100%;height:300px"></model-viewer>
+  {% endif %}
+  <form class="mt-2">
+    <input type="file" name="file" accept=".glb" hx-post="/testmacros/{{ macro.id }}/upload_glb" hx-include="closest form" hx-target="#drawer" hx-swap="outerHTML" class="upload-btn" />
+  </form>
+  <h3 class="font-bold mt-4">Linked Parts</h3>
+  <ul>
+  {% for p in parts %}
+    <li class="flex items-center justify-between">
+      <span>{{ p.id }} - {{ p.number }}</span>
+      <button class="del-btn text-red-600" hx-delete="/parts/{{ p.id }}/testmacros/{{ macro.id }}" hx-target="#drawer" hx-swap="outerHTML">✖</button>
+    </li>
+  {% endfor %}
+  </ul>
+  <script>checkOperator();</script>
+</div>

--- a/app/frontend/templates/testassets.html
+++ b/app/frontend/templates/testassets.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="text-2xl mb-4">Test Assets</h1>
-<p>Coming soon.</p>
+<table class="min-w-full" hx-get="/ui/testassets/table" hx-trigger="load" hx-target="this"></table>
+<div id="drawer"></div>
 {% endblock %}

--- a/app/frontend/templates/testassets_table.html
+++ b/app/frontend/templates/testassets_table.html
@@ -1,0 +1,19 @@
+<tbody>
+{% for m in macros %}
+<tr>
+  <td class="px-2">{{ m.id }}</td>
+  <td class="px-2">{{ m.name }}</td>
+  <td class="px-2"><span class="bg-sky-600 text-white text-xs px-1 rounded">{{ m.usage_count }}</span></td>
+  <td class="px-2">
+  {% if m.glb_path %}
+    <model-viewer src="/{{ m.glb_path }}" camera-controls style="width:80px;height:80px"></model-viewer>
+  {% else %}-{% endif %}
+  </td>
+  <td class="px-2">
+    <button hx-get="/ui/testassets/detail/{{ m.id }}" hx-target="#drawer" class="upload-btn bg-blue-500 text-white px-1 mr-1">Upload</button>
+    <button hx-get="/ui/testassets/detail/{{ m.id }}" hx-target="#drawer" class="bg-gray-500 text-white px-1">Preview</button>
+  </td>
+</tr>
+{% endfor %}
+</tbody>
+<script>checkOperator();</script>

--- a/tests/test_testassets_ui.py
+++ b/tests/test_testassets_ui.py
@@ -1,0 +1,49 @@
+import sqlalchemy, pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app.main as main
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post("/auth/token", data={"username": "admin", "password": "change_me"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_table_and_detail(client, auth_header):
+    macro = client.post("/testmacros", json={"name": "M"}, headers=auth_header).json()
+    p1 = client.post("/parts", json={"number": "P1"}, headers=auth_header).json()
+    p2 = client.post("/parts", json={"number": "P2"}, headers=auth_header).json()
+    client.post(f"/parts/{p1['id']}/testmacros", json={"test_macro_id": macro['id']}, headers=auth_header)
+    client.post(f"/parts/{p2['id']}/testmacros", json={"test_macro_id": macro['id']}, headers=auth_header)
+
+    r = client.get("/ui/testassets/table")
+    assert r.status_code == 200
+    assert "<tbody" in r.text
+    assert "M" in r.text
+    assert "2" in r.text
+
+    data = b"glTF"
+    up = client.post(
+        f"/testmacros/{macro['id']}/upload_glb",
+        files={"file": ("m.glb", data, "model/gltf-binary")},
+        headers=auth_header,
+    )
+    assert up.status_code == 200
+
+    detail = client.get(f"/ui/testassets/detail/{macro['id']}")
+    assert detail.status_code == 200
+    assert "<model-viewer" in detail.text


### PR DESCRIPTION
## Summary
- enable Test Assets GUI table and details drawer
- allow GLB uploads via HTMX
- expose `/testmacros/{id}/parts` endpoint
- embed model-viewer script
- cover new behaviour with tests
- remove binary screenshot from docs

## Testing
- `pytest -q tests/test_testassets_ui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fe1bd931c832cbedcca54a4db04fa