### PR TITLE
Implement UI for Complex and PythonTest assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,12 @@ Download files via `/assets/{sha}/{name}`.
 
 Example:
 ```bash
-curl http://localhost:8000/ui/testassets/table
+curl http://localhost:8000/ui/testassets/table?kind=complex
+curl http://localhost:8000/ui/testassets/table?kind=py
 ```
+
+Use the search box to filter assets by name.
+
 
 Workflow inline editing with the clip icon is shown in the documentation.
 

--- a/app/frontend/templates/testasset_detail.html
+++ b/app/frontend/templates/testasset_detail.html
@@ -1,20 +1,36 @@
 <div id="drawer" class="p-4 border">
-  <h2 class="text-xl mb-2">{{ macro.name }}</h2>
-  <p>ID: {{ macro.id }}</p>
-  {% if macro.glb_path %}
-  <model-viewer src="/{{ macro.glb_path }}" alt="{{ macro.name }}" camera-controls ar style="width:100%;height:300px"></model-viewer>
+  <h2 class="text-xl mb-2">{{ obj.name }}</h2>
+  <p>ID: {{ obj.id }}</p>
+  {% if kind == 'macro' and obj.glb_path %}
+    <model-viewer src="/{{ obj.glb_path }}" alt="{{ obj.name }}" camera-controls ar style="width:100%;height:300px"></model-viewer>
+  {% elif kind == 'complex' and obj.eda_path %}
+    <a href="/{{ obj.eda_path }}" class="text-blue-600">Download ZIP</a>
+  {% elif kind == 'py' and obj.file_path %}
+    <pre><code id="code-block"></code></pre>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
+    <script>
+      fetch('/{{ obj.file_path }}').then(r=>r.text()).then(t=>{document.getElementById('code-block').textContent=t;hljs.highlightAll&&hljs.highlightAll();});
+    </script>
   {% endif %}
   <form class="mt-2">
-    <input type="file" name="file" accept=".glb" hx-post="/testmacros/{{ macro.id }}/upload_glb" hx-include="closest form" hx-target="#drawer" hx-swap="outerHTML" class="upload-btn" />
+    {% if kind == 'macro' %}
+      <input type="file" name="file" accept=".glb" hx-post="/testmacros/{{ obj.id }}/upload_glb" hx-include="closest form" hx-target="#drawer" hx-swap="outerHTML" class="upload-btn" />
+    {% elif kind == 'complex' %}
+      <input type="file" name="file" accept=".zip" hx-post="/complexes/{{ obj.id }}/upload_eda" hx-include="closest form" hx-target="#drawer" hx-swap="outerHTML" class="upload-btn" />
+    {% elif kind == 'py' %}
+      <input type="file" name="file" accept=".py" hx-post="/pythontests/{{ obj.id }}/upload_file" hx-include="closest form" hx-target="#drawer" hx-swap="outerHTML" class="upload-btn" />
+    {% endif %}
   </form>
+  {% if kind == 'macro' %}
   <h3 class="font-bold mt-4">Linked Parts</h3>
   <ul>
   {% for p in parts %}
     <li class="flex items-center justify-between">
       <span>{{ p.id }} - {{ p.number }}</span>
-      <button class="del-btn text-red-600" hx-delete="/parts/{{ p.id }}/testmacros/{{ macro.id }}" hx-target="#drawer" hx-swap="outerHTML">✖</button>
+      <button class="del-btn text-red-600" hx-delete="/parts/{{ p.id }}/testmacros/{{ obj.id }}" hx-target="#drawer" hx-swap="outerHTML">✖</button>
     </li>
   {% endfor %}
   </ul>
+  {% endif %}
   <script>checkOperator();</script>
 </div>

--- a/app/frontend/templates/testassets.html
+++ b/app/frontend/templates/testassets.html
@@ -1,6 +1,14 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="text-2xl mb-4">Test Assets</h1>
-<table class="min-w-full" hx-get="/ui/testassets/table" hx-trigger="load" hx-target="this"></table>
+<div class="mb-2 space-x-2">
+  <button hx-get="/ui/testassets/table?kind=macro" hx-target="#asset-table" onclick="document.getElementById('kind-field').value='macro'" class="px-1 bg-gray-200">Test Macros</button>
+  <button hx-get="/ui/testassets/table?kind=complex" hx-target="#asset-table" onclick="document.getElementById('kind-field').value='complex'" class="px-1 bg-gray-200">Complexes</button>
+  <button hx-get="/ui/testassets/table?kind=py" hx-target="#asset-table" onclick="document.getElementById('kind-field').value='py'" class="px-1 bg-gray-200">Python Tests</button>
+  <input id="asset-search" name="q" class="border px-1" hx-get="/ui/testassets/table" hx-trigger="keyup changed delay:250ms" hx-target="#asset-table" hx-include="#kind-field" />
+  <input type="hidden" id="kind-field" name="kind" value="macro" />
+</div>
+<table id="asset-table" class="min-w-full" hx-get="/ui/testassets/table" hx-trigger="load" hx-target="this" hx-vals='{"kind":"macro"}'></table>
 <div id="drawer"></div>
+<script>checkOperator();</script>
 {% endblock %}

--- a/app/frontend/templates/testassets_table.html
+++ b/app/frontend/templates/testassets_table.html
@@ -1,17 +1,23 @@
 <tbody>
-{% for m in macros %}
+{% for a in assets %}
 <tr>
-  <td class="px-2">{{ m.id }}</td>
-  <td class="px-2">{{ m.name }}</td>
-  <td class="px-2"><span class="bg-sky-600 text-white text-xs px-1 rounded">{{ m.usage_count }}</span></td>
+  <td class="px-2">{{ a.id }}</td>
+  <td class="px-2">{{ a.name }}</td>
+  <td class="px-2"><span class="bg-sky-600 text-white text-xs px-1 rounded">{{ a.usage_count or 0 }}</span></td>
   <td class="px-2">
-  {% if m.glb_path %}
-    <model-viewer src="/{{ m.glb_path }}" camera-controls style="width:80px;height:80px"></model-viewer>
-  {% else %}-{% endif %}
+  {% if kind == 'macro' %}
+    {% if a.glb_path %}
+      <model-viewer src="/{{ a.glb_path }}" camera-controls style="width:80px;height:80px"></model-viewer>
+    {% else %}-{% endif %}
+  {% elif kind == 'complex' %}
+    {% if a.eda_path %}<a href="/{{ a.eda_path }}">ZIP</a>{% else %}-{% endif %}
+  {% elif kind == 'py' %}
+    {% if a.file_path %}<a href="/{{ a.file_path }}">Download</a>{% else %}-{% endif %}
+  {% endif %}
   </td>
   <td class="px-2">
-    <button hx-get="/ui/testassets/detail/{{ m.id }}" hx-target="#drawer" class="upload-btn bg-blue-500 text-white px-1 mr-1">Upload</button>
-    <button hx-get="/ui/testassets/detail/{{ m.id }}" hx-target="#drawer" class="bg-gray-500 text-white px-1">Preview</button>
+    <button hx-get="/ui/testassets/detail{% if kind != 'macro' %}/{{ kind }}{% endif %}/{{ a.id }}" hx-target="#drawer" class="upload-btn bg-blue-500 text-white px-1 mr-1">Upload</button>
+    <button hx-get="/ui/testassets/detail{% if kind != 'macro' %}/{{ kind }}{% endif %}/{{ a.id }}" hx-target="#drawer" class="bg-gray-500 text-white px-1">Preview</button>
   </td>
 </tr>
 {% endfor %}

--- a/tests/test_asset_tables.py
+++ b/tests/test_asset_tables.py
@@ -1,0 +1,37 @@
+import sqlalchemy, pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app.main as main
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post("/auth/token", data={"username": "admin", "password": "change_me"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_complex_py_tables(client, auth_header):
+    cplx = client.post("/complexes", json={"name": "Board"}, headers=auth_header).json()
+    pyt = client.post("/pythontests", json={"name": "Test"}, headers=auth_header).json()
+    part = client.post("/parts", json={"number": "P1"}, headers=auth_header).json()
+    # upload dummy files
+    client.post(f"/complexes/{cplx['id']}/upload_eda", files={"file": ("b.zip", b"ZIP", "application/zip")}, headers=auth_header)
+    client.post(f"/pythontests/{pyt['id']}/upload_file", files={"file": ("t.py", b"print()", "text/x-python")}, headers=auth_header)
+    r = client.get("/ui/testassets/table?kind=complex")
+    assert r.status_code == 200
+    assert "<a" in r.text and "Board" in r.text
+    r2 = client.get(f"/ui/testassets/detail/py/{pyt['id']}")
+    assert "<pre><code" in r2.text


### PR DESCRIPTION
## Summary
- add tabbed Test Assets page with search
- support Complex and PythonTest detail drawers
- implement `/complexes/{cid}/parts` and `/pythontests/{pid}/parts`
- allow upload/download for zip/py files in UI
- document new endpoints and search
- add regression test for asset tables
- remove unsupported screenshot from docs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686051be879c832c8df21ba1c0d25731