### PR TITLE
Implement asset–part links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ curl http://localhost:8000/inventory
 ```
 Inline edits are available under `/ui/inventory`.
 
-Each Part can have one-or-more "Test Macros" attached (fixtures, Python tests, 3-D models, etc.).
-Use `/parts/{id}/testmacros` to manage these links.
+Each Part can have one-or-more Test Assets attached (macros, complexes or Python tests).
+Use `/parts/{id}/testmacros`, `/parts/{id}/complexes` and `/parts/{id}/pythontests` to manage these links.
 
 ### Test results
 
@@ -257,6 +257,21 @@ EDA Bundle   POST /complexes/{id}/upload_eda     .zip ≤ 20 MB
 Python Test  POST /pythontests/{id}/upload_file  .py ≤ 1 MB
 
 Download files via `/assets/{sha}/{name}`.
+
+Link Parts to a complex or Python test:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"complex_id":1}' /parts/5/complexes
+curl -X DELETE /parts/5/pythontests/2
+```
+
+List linked parts:
+
+```bash
+curl /complexes/1/parts
+curl /pythontests/2/parts
+```
 
 
 Example:

--- a/app/frontend/templates/testasset_detail.html
+++ b/app/frontend/templates/testasset_detail.html
@@ -21,13 +21,19 @@
       <input type="file" name="file" accept=".py" hx-post="/pythontests/{{ obj.id }}/upload_file" hx-include="closest form" hx-target="#drawer" hx-swap="outerHTML" class="upload-btn" />
     {% endif %}
   </form>
-  {% if kind == 'macro' %}
+  {% if kind in ['macro','complex','py'] %}
   <h3 class="font-bold mt-4">Linked Parts</h3>
   <ul>
   {% for p in parts %}
     <li class="flex items-center justify-between">
       <span>{{ p.id }} - {{ p.number }}</span>
+      {% if kind == 'macro' %}
       <button class="del-btn text-red-600" hx-delete="/parts/{{ p.id }}/testmacros/{{ obj.id }}" hx-target="#drawer" hx-swap="outerHTML">✖</button>
+      {% elif kind == 'complex' %}
+      <button class="del-btn text-red-600" hx-delete="/parts/{{ p.id }}/complexes/{{ obj.id }}" hx-target="#drawer" hx-swap="outerHTML">✖</button>
+      {% elif kind == 'py' %}
+      <button class="del-btn text-red-600" hx-delete="/parts/{{ p.id }}/pythontests/{{ obj.id }}" hx-target="#drawer" hx-swap="outerHTML">✖</button>
+      {% endif %}
     </li>
   {% endfor %}
   </ul>

--- a/migrations/versions/0005_asset_part_links.py
+++ b/migrations/versions/0005_asset_part_links.py
@@ -1,0 +1,20 @@
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'complex_part_map',
+        sa.Column('part_id', sa.Integer, sa.ForeignKey('part.id', ondelete='CASCADE'), primary_key=True, nullable=False),
+        sa.Column('complex_id', sa.Integer, sa.ForeignKey('complex.id', ondelete='CASCADE'), primary_key=True, nullable=False),
+    )
+    op.create_table(
+        'pythontest_part_map',
+        sa.Column('part_id', sa.Integer, sa.ForeignKey('part.id', ondelete='CASCADE'), primary_key=True, nullable=False),
+        sa.Column('pythontest_id', sa.Integer, sa.ForeignKey('pythontest.id', ondelete='CASCADE'), primary_key=True, nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('pythontest_part_map')
+    op.drop_table('complex_part_map')

--- a/tests/test_asset_links.py
+++ b/tests/test_asset_links.py
@@ -1,0 +1,55 @@
+import sqlalchemy, pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app.main as main
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    with TestClient(main.app) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_header(client):
+    token = client.post("/auth/token", data={"username": "admin", "password": "change_me"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_asset_links(client, auth_header):
+    part = client.post("/parts", json={"number": "P1"}, headers=auth_header).json()
+    cplx = client.post("/complexes", json={"name": "Board"}, headers=auth_header).json()
+    pyt = client.post("/pythontests", json={"name": "Test"}, headers=auth_header).json()
+
+    client.post(f"/parts/{part['id']}/complexes", json={"complex_id": cplx['id']}, headers=auth_header)
+    client.post(f"/parts/{part['id']}/pythontests", json={"pythontest_id": pyt['id']}, headers=auth_header)
+
+    assert client.get(f"/complexes/{cplx['id']}/parts", headers=auth_header).json()[0]['id'] == part['id']
+    assert client.get(f"/pythontests/{pyt['id']}/parts", headers=auth_header).json()[0]['id'] == part['id']
+
+    d1 = client.get(f"/ui/testassets/detail/complex/{cplx['id']}")
+    assert "P1" in d1.text
+    d2 = client.get(f"/ui/testassets/detail/py/{pyt['id']}")
+    assert "P1" in d2.text
+
+    client.delete(f"/parts/{part['id']}/complexes/{cplx['id']}", headers=auth_header)
+    client.delete(f"/parts/{part['id']}/pythontests/{pyt['id']}", headers=auth_header)
+
+    assert client.get(f"/complexes/{cplx['id']}/parts", headers=auth_header).json() == []
+    assert client.get(f"/pythontests/{pyt['id']}/parts", headers=auth_header).json() == []
+
+    # cascade
+    client.post(f"/parts/{part['id']}/complexes", json={"complex_id": cplx['id']}, headers=auth_header)
+    client.post(f"/parts/{part['id']}/pythontests", json={"pythontest_id": pyt['id']}, headers=auth_header)
+    client.delete(f"/parts/{part['id']}", headers=auth_header)
+    assert client.get(f"/complexes/{cplx['id']}/parts", headers=auth_header).json() == []
+    assert client.get(f"/pythontests/{pyt['id']}/parts", headers=auth_header).json() == []


### PR DESCRIPTION
## Summary
- create complex_part_map and pythontest_part_map tables
- expose usage counters for all asset types
- allow linking/unlinking Parts to Complexes and PythonTests
- return updated HTML on HX link/unlink
- show linked Parts in complex/python detail drawer
- document new endpoints
- test linking logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860b8c9ba58832c8b68a816c63c0e75