### PR TITLE
Add BOM template download and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Import a BOM file:
 curl -F file=@sample.pdf http://localhost:8000/bom/import
 curl -F file=@bom.csv http://localhost:8000/bom/import
 ```
+Download a starter template with `curl -O http://localhost:8000/bom/template`.
 CSV columns may include `manufacturer`, `mpn`, `footprint` and `unit_cost`.
 
 ### Customers & Projects
@@ -122,6 +123,7 @@ Inline edits are available under `/ui/inventory`.
 
 Each Part can have one-or-more Test Assets attached (macros, complexes or Python tests).
 Use `/parts/{id}/testmacros`, `/parts/{id}/complexes` and `/parts/{id}/pythontests` to manage these links.
+List macros linked to a part via `GET /parts/{id}/testmacros`.
 
 ### Test results
 
@@ -258,11 +260,16 @@ Python Test  POST /pythontests/{id}/upload_file  .py ≤ 1 MB
 
 Download files via `/assets/{sha}/{name}`.
 
-Link Parts to a complex or Python test:
-
+Link or unlink Parts and Test Assets:
 ```bash
 curl -X POST -H "Content-Type: application/json" \
+     -d '{"test_macro_id":1}' /parts/5/testmacros
+curl -X DELETE /parts/5/testmacros/1
+curl -X POST -H "Content-Type: application/json" \
      -d '{"complex_id":1}' /parts/5/complexes
+curl -X DELETE /parts/5/complexes/1
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"pythontest_id":2}' /parts/5/pythontests
 curl -X DELETE /parts/5/pythontests/2
 ```
 

--- a/app/frontend/templates/import.html
+++ b/app/frontend/templates/import.html
@@ -1,8 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="text-2xl mb-4">Import BOM</h1>
+<p class="text-sm text-gray-600" title="part_number/number, description/desc, quantity/qty, reference/ref, manufacturer, mpn, footprint, unit_cost, currency, dnp">Accepted columns: part_number, description, quantity and optional fields like manufacturer or unit_cost.</p>
 <form hx-post="/bom/import" enctype="multipart/form-data" class="space-y-2">
   <input type="file" name="file" accept=".pdf,.csv,.xlsx" required>
   <button id="import-btn" type="submit" class="bg-blue-500 text-white px-2">Upload</button>
+  <a href="/bom/template" class="bg-gray-500 text-white px-2">Download sample</a>
 </form>
 {% endblock %}

--- a/app/frontend/templates/workflow.html
+++ b/app/frontend/templates/workflow.html
@@ -31,6 +31,7 @@
   <h2 class="font-bold">3. Upload BOM</h2>
   <input type="file" id="bom-file" accept=".csv,.xlsx" class="border" />
   <button id="upload-bom" class="bg-blue-500 text-white px-2">Upload</button>
+  <a href="/bom/template" class="bg-gray-500 text-white px-2">Download sample</a>
 </div>
 <div id="step-4" class="mb-4 hidden">
   <h2 class="font-bold">4. Review</h2>

--- a/app/main.py
+++ b/app/main.py
@@ -2109,6 +2109,14 @@ def get_test_result(test_id: int) -> TestResultRead:
         return result
 
 
+@app.get("/bom/template")
+def bom_template() -> StreamingResponse:
+    """Download a CSV template for BOM imports."""
+    path = Path(__file__).resolve().parent.parent / "bom_template.csv"
+    headers = {"Content-Disposition": "attachment; filename=bom_template.csv"}
+    return StreamingResponse(path.open("rb"), media_type="text/csv", headers=headers)
+
+
 @app.get("/export/bom.csv", dependencies=[Depends(admin_required)])
 def export_bom_csv():
     items = get_all_bom()

--- a/bom_template.csv
+++ b/bom_template.csv
@@ -1,0 +1,3 @@
+part_number,description,quantity,reference,manufacturer,mpn,footprint,unit_cost,currency,dnp
+ABC123,10 kΩ 0805 resistor,10,R1-R10,Yageo,RC0805FR-0710KL,0805,0.012,USD,
+LM358,Pwr op-amp SOIC-8,2,U1-U2,TI,LM358DR,SOIC-8,,USD,

--- a/tests/test_template_download.py
+++ b/tests/test_template_download.py
@@ -1,0 +1,26 @@
+import os, sys, sqlalchemy
+from sqlmodel import SQLModel, create_engine
+from fastapi.testclient import TestClient
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import app.main as main
+
+
+def setup_client():
+    engine = create_engine(
+        'sqlite:///:memory:',
+        connect_args={'check_same_thread': False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    main.engine = engine
+    SQLModel.metadata.create_all(engine)
+    return TestClient(main.app)
+
+
+def test_bom_template_download():
+    with setup_client() as client:
+        r = client.get('/bom/template')
+        assert r.status_code == 200
+        header = r.text.splitlines()[0]
+        assert header == 'part_number,description,quantity,reference,manufacturer,mpn,footprint,unit_cost,currency,dnp'
+
+


### PR DESCRIPTION
## Summary
- document `/bom/template` endpoint and unlink routes
- add sample BOM template file
- provide new `/bom/template` endpoint
- show accepted column aliases and 'Download sample' option in GUI
- add unit test for template download

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860bd048188832c9838ee465181d786