### PR TITLE
Fix workflow save using assembly ID

### DIFF
--- a/app/frontend/templates/workflow.html
+++ b/app/frontend/templates/workflow.html
@@ -345,7 +345,13 @@ document.getElementById('save-bom').onclick=async ()=>{
       currency: sel?sel.value:DEFAULT_CURRENCY
     });
   });
-  const resp=await authFetch('/ui/workflow/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({project_id:parseInt(project),items:payload})});
+  const asmRes=await authFetch(`/projects/${project}/assemblies`);
+  if(!asmRes.ok){
+    showToast("Assembly lookup failed",false);return;
+  }
+  const assemblyId=(await asmRes.json())[0]?.id;
+  if(!assemblyId){showToast("No assembly",false);return;}
+  const resp=await authFetch('/ui/workflow/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({assembly_id:parseInt(assemblyId),items:payload})});
   if(resp.ok){
     items=await resp.json();
     renderPage();


### PR DESCRIPTION
## Summary
- update workflow wizard to fetch assembly ID for the selected project
- POST `assembly_id` instead of `project_id` when saving BOM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686122b619ac832c9d06af50b6de5708