### PR TITLE
feat: add PySide6 debug GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,29 +303,15 @@ Workflow inline editing with the clip icon is shown in the documentation.
 
 ### 📋 Server Control Center GUI
 
-Launch the graphical control center from a virtual environment on a session that can open windows (RDP or local login):
+Install the optional GUI dependencies and launch:
 
 ```bash
-bom-gui               # or:  python -m gui.control_center
+python -m pip install -e .[full]
+bom-gui
 ```
 
-This window lets you start and stop the API server, run tests, trigger backups and download exports without using the terminal.
+Use **Backend = Local** for an in-memory API or switch to **HTTP** to talk to a running server.
+Tabs include Quick Actions (import/seed/export helpers), Auth, DB settings, an HTTP playground and an optional Server controller.
+The toolbar’s “Download BOM template” button fetches the same CSV exposed at [`GET /bom/template`](./app/main.py).
 
 ![GUI screenshot](docs/gui_screenshot.png)
-
-### One-click install
-
-Windows:
-```bat
-scripts\setup.bat
-```
-
-Linux/macOS:
-```bash
-chmod +x scripts/setup.sh
-./scripts/setup.sh
-```
-
-The script creates a virtual environment, installs all optional dependencies and launches the Control Center.
-It now detects the project root and directly invokes the Python inside `.venv`,
-so it works even if `python` isn't on your PATH.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,1 @@
+"""Desktop debug GUI package."""

--- a/gui/api_client/__init__.py
+++ b/gui/api_client/__init__.py
@@ -1,0 +1,7 @@
+"""API client backends for the debug GUI."""
+
+from .base import BaseClient
+from .http_client import HTTPClient
+from .local_client import LocalClient
+
+__all__ = ["BaseClient", "HTTPClient", "LocalClient"]

--- a/gui/api_client/base.py
+++ b/gui/api_client/base.py
@@ -1,0 +1,91 @@
+"""API client abstraction for the debug GUI.
+
+This module defines :class:`BaseClient` which wraps the small subset of
+functionality required by the GUI.  Concrete implementations simply need to
+implement :meth:`request` to perform an HTTP like call and return an object
+with ``status_code``, ``json()``, ``text`` and ``content`` attributes (matching
+``httpx.Response``/``requests.Response``).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class BaseClient(ABC):
+    """Small facade used by the GUI panels.
+
+    The interface purposely mirrors the common subset between ``requests`` and
+    ``httpx`` responses so that the same widgets can operate with either the
+    in-memory TestClient or a real HTTP client.
+    """
+
+    def __init__(self) -> None:
+        self._token: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # request helpers
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None):
+        return self.request("GET", path, params=params)
+
+    def post(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ):
+        return self.request(
+            "POST", path, params=params, data=data, json=json, files=files
+        )
+
+    def patch(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+    ):
+        return self.request("PATCH", path, params=params, data=data, json=json)
+
+    def delete(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+    ):
+        return self.request("DELETE", path, params=params, data=data)
+
+    # ------------------------------------------------------------------
+    @abstractmethod
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ):
+        """Perform a request and return the raw response object."""
+
+    # ------------------------------------------------------------------
+    def set_token(self, token: Optional[str]) -> None:
+        """Set the bearer token to be used for subsequent requests."""
+
+        self._token = token
+
+    # ------------------------------------------------------------------
+    def _auth_header(self) -> Dict[str, str]:
+        if not self._token:
+            return {}
+        return {"Authorization": f"Bearer {self._token}"}
+
+    # ------------------------------------------------------------------
+    def is_local(self) -> bool:
+        """Return ``True`` if this client talks to an in-memory API."""
+
+        return False

--- a/gui/api_client/http_client.py
+++ b/gui/api_client/http_client.py
@@ -1,0 +1,54 @@
+"""HTTP client backend using :mod:`httpx`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .base import BaseClient
+
+
+class HTTPClient(BaseClient):
+    """Client that talks to a running API server via HTTP."""
+
+    def __init__(self, base_url: str = "http://localhost:8000") -> None:
+        super().__init__()
+        self.base_url = base_url.rstrip("/")
+        self._client = httpx.Client(base_url=self.base_url, timeout=10.0)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ):
+        headers = self._auth_header()
+        try:
+            return self._client.request(
+                method,
+                path,
+                params=params,
+                data=data,
+                json=json,
+                files=files,
+                headers=headers,
+            )
+        except httpx.HTTPError as exc:  # pragma: no cover - network errors
+            class _Error:
+                def __init__(self, message: str) -> None:
+                    self.status_code = 0
+                    self.text = message
+                    self.content = b""
+
+                def json(self) -> Dict[str, Any]:
+                    return {}
+
+            return _Error(str(exc))
+
+    def close(self) -> None:
+        self._client.close()

--- a/gui/api_client/local_client.py
+++ b/gui/api_client/local_client.py
@@ -1,0 +1,53 @@
+"""In-memory API client using :class:`fastapi.testclient.TestClient`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi.testclient import TestClient
+
+from .base import BaseClient
+
+
+class LocalClient(BaseClient):
+    """Client that runs the FastAPI app in-memory.
+
+    This allows the GUI to call the same endpoints without requiring an HTTP
+    server to be running.  The first instantiation performs the database
+    initialisation by calling :func:`app.main.init_db`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        from app import main
+
+        # Ensure the database and application are initialised
+        main.init_db()
+        self._app = main.app
+        self._client = TestClient(self._app)
+
+    # ------------------------------------------------------------------
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ):
+        headers = self._auth_header()
+        return self._client.request(
+            method,
+            path,
+            params=params,
+            data=data,
+            json=json,
+            files=files,
+            headers=headers,
+        )
+
+    # ------------------------------------------------------------------
+    def is_local(self) -> bool:  # pragma: no cover - trivial
+        return True

--- a/gui/util/__init__.py
+++ b/gui/util/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for the GUI."""

--- a/gui/util/qt.py
+++ b/gui/util/qt.py
@@ -1,0 +1,25 @@
+"""Small Qt helper utilities used across widgets."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox, QWidget
+
+
+def alert(parent: QWidget, title: str, text: str) -> None:
+    QMessageBox.information(parent, title, text)
+
+
+def error(parent: QWidget, title: str, text: str) -> None:
+    QMessageBox.critical(parent, title, text)
+
+
+def confirm(parent: QWidget, title: str, text: str) -> bool:
+    return QMessageBox.question(parent, title, text) == QMessageBox.StandardButton.Yes
+
+
+def pick_file(parent: QWidget, caption: str, filt: str = "*") -> str:
+    return QFileDialog.getOpenFileName(parent, caption, filter=filt)[0]
+
+
+def save_file(parent: QWidget, caption: str, filt: str = "*") -> str:
+    return QFileDialog.getSaveFileName(parent, caption, filter=filt)[0]

--- a/gui/widgets/__init__.py
+++ b/gui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Qt widgets for the debug GUI."""

--- a/gui/widgets/api_playground.py
+++ b/gui/widgets/api_playground.py
@@ -1,0 +1,97 @@
+"""Minimal HTTP playground widget."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QComboBox,
+    QPushButton,
+    QTextEdit,
+    QLabel,
+)
+
+from ..api_client import BaseClient
+from ..util import qt
+
+
+class APIPlayground(QWidget):
+    """Tiny playground to issue ad-hoc requests."""
+
+    def __init__(self, client: BaseClient) -> None:
+        super().__init__()
+        self._client = client
+
+        layout = QVBoxLayout(self)
+        top = QHBoxLayout()
+        self.method = QComboBox()
+        self.method.addItems(["GET", "POST", "PATCH", "DELETE"])
+        top.addWidget(self.method)
+        self.path_edit = QLineEdit("/")
+        top.addWidget(self.path_edit)
+        send_btn = QPushButton("Send")
+        send_btn.clicked.connect(self.send)
+        top.addWidget(send_btn)
+        layout.addLayout(top)
+
+        file_row = QHBoxLayout()
+        self.file_edit = QLineEdit()
+        file_btn = QPushButton("Choose file")
+        file_btn.clicked.connect(self.choose_file)
+        file_row.addWidget(self.file_edit)
+        file_row.addWidget(file_btn)
+        layout.addLayout(file_row)
+
+        self.request_body = QTextEdit()
+        self.request_body.setPlaceholderText("JSON body")
+        layout.addWidget(self.request_body)
+
+        layout.addWidget(QLabel("Response:"))
+        self.response_view = QTextEdit()
+        self.response_view.setReadOnly(True)
+        layout.addWidget(self.response_view)
+
+    # ------------------------------------------------------------------
+    def set_client(self, client: BaseClient) -> None:
+        self._client = client
+
+    # ------------------------------------------------------------------
+    def send(self) -> None:
+        path = self.path_edit.text()
+        method = self.method.currentText()
+        files = None
+        json = None
+        file_path = self.file_edit.text().strip()
+        if file_path:
+            try:
+                f = open(file_path, "rb")
+                files = {"file": (file_path.split("/")[-1], f)}
+            except OSError as exc:  # pragma: no cover - user input
+                qt.error(self, "File", str(exc))
+                return
+        else:
+            body = self.request_body.toPlainText().strip()
+            if body:
+                try:
+                    import json as _json
+
+                    json = _json.loads(body)
+                except Exception as exc:  # pragma: no cover - user input
+                    qt.error(self, "Invalid JSON", str(exc))
+                    return
+        try:
+            resp = self._client.request(method, path, json=json, files=files)
+        finally:
+            if files:
+                files["file"][1].close()
+        self.response_view.setPlainText(
+            f"Status: {resp.status_code}\n{resp.text}"
+        )
+
+    # ------------------------------------------------------------------
+    def choose_file(self) -> None:
+        path = qt.pick_file(self, "Choose file")
+        if path:
+            self.file_edit.setText(path)

--- a/gui/widgets/auth_panel.py
+++ b/gui/widgets/auth_panel.py
@@ -1,0 +1,88 @@
+"""Authentication panel."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QLabel,
+    QHBoxLayout,
+)
+
+from ..api_client import BaseClient
+from ..util import qt
+
+
+class AuthPanel(QWidget):
+    """Simple username/password login widget."""
+
+    def __init__(self, client: BaseClient, login_cb: Optional[Callable[[str], None]] = None) -> None:
+        super().__init__()
+        self._client = client
+        self._login_cb = login_cb
+
+        layout = QVBoxLayout(self)
+        form = QHBoxLayout()
+        self.user_edit = QLineEdit()
+        self.user_edit.setPlaceholderText("username")
+        self.pass_edit = QLineEdit()
+        self.pass_edit.setPlaceholderText("password")
+        self.pass_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        form.addWidget(self.user_edit)
+        form.addWidget(self.pass_edit)
+        layout.addLayout(form)
+
+        btns = QHBoxLayout()
+        login_btn = QPushButton("Login")
+        login_btn.clicked.connect(self.login)
+        btns.addWidget(login_btn)
+        clear_btn = QPushButton("Clear")
+        clear_btn.clicked.connect(self.clear_token)
+        btns.addWidget(clear_btn)
+        me_btn = QPushButton("Who am I?")
+        me_btn.clicked.connect(self.show_me)
+        btns.addWidget(me_btn)
+        layout.addLayout(btns)
+
+        self.token_label = QLabel("<no token>")
+        layout.addWidget(self.token_label)
+
+    # ------------------------------------------------------------------
+    def set_client(self, client: BaseClient) -> None:
+        self._client = client
+
+    # ------------------------------------------------------------------
+    def login(self) -> None:
+        resp = self._client.post(
+            "/auth/token",
+            data={"username": self.user_edit.text(), "password": self.pass_edit.text()},
+        )
+        if resp.status_code == 200:
+            token = resp.json().get("access_token")
+            self._client.set_token(token)
+            self.token_label.setText(token[:16] + "…")
+            if self._login_cb:
+                self._login_cb(token)
+        else:
+            qt.error(self, "Login failed", resp.text)
+
+    # ------------------------------------------------------------------
+    def clear_token(self) -> None:
+        self._client.set_token(None)
+        self.token_label.setText("<no token>")
+        if self._login_cb:
+            self._login_cb("")
+
+    # ------------------------------------------------------------------
+    def show_me(self) -> None:
+        resp = self._client.get("/auth/me")
+        if resp.status_code == 200:
+            data = resp.json()
+            qt.alert(self, "Me", f"{data.get('username')} ({data.get('role')})")
+        else:
+            qt.error(self, "Error", resp.text)

--- a/gui/widgets/db_panel.py
+++ b/gui/widgets/db_panel.py
@@ -1,0 +1,107 @@
+"""Database configuration panel."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QLabel,
+)
+from sqlalchemy import text
+
+from ..api_client import BaseClient
+from ..util import qt
+
+
+class DBPanel(QWidget):
+    """Display and modify the ``DATABASE_URL`` setting."""
+
+    def __init__(self, client: BaseClient) -> None:
+        super().__init__()
+        self._client = client
+
+        layout = QVBoxLayout(self)
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Database URL:"))
+        self.url_edit = QLineEdit()
+        row.addWidget(self.url_edit)
+        layout.addLayout(row)
+
+        btns = QHBoxLayout()
+        self.save_btn = QPushButton("Save")
+        self.save_btn.clicked.connect(self.save)
+        btns.addWidget(self.save_btn)
+        reload_btn = QPushButton("Reload")
+        reload_btn.clicked.connect(self.reload)
+        btns.addWidget(reload_btn)
+        test_btn = QPushButton("Test")
+        test_btn.clicked.connect(self.test)
+        btns.addWidget(test_btn)
+        layout.addLayout(btns)
+        self.status = QLabel("")
+        layout.addWidget(self.status)
+
+        self.reload()
+
+    # ------------------------------------------------------------------
+    def set_client(self, client: BaseClient) -> None:
+        self._client = client
+        self.reload()
+
+    # ------------------------------------------------------------------
+    def reload(self) -> None:
+        if self._client.is_local():
+            from app import config
+
+            self.url_edit.setReadOnly(False)
+            self.save_btn.setEnabled(True)
+            self.url_edit.setText(config.DATABASE_URL)
+        else:
+            # HTTP backend is read-only; just display the base URL if available
+            base = getattr(self._client, "base_url", self.url_edit.text())
+            self.url_edit.setText(base)
+            self.url_edit.setReadOnly(True)
+            self.save_btn.setEnabled(False)
+        self.status.setText("")
+
+    # ------------------------------------------------------------------
+    def save(self) -> None:
+        new_url = self.url_edit.text()
+        if self._client.is_local():
+            from app import config
+
+            config.save_database_url(new_url)
+            config.reload_settings()
+            qt.alert(self, "DB", "Saved")
+        else:
+            resp = self._client.post("/ui/settings", json={"database_url": new_url})
+            if resp.status_code == 200:
+                qt.alert(self, "DB", "Saved")
+            else:
+                qt.error(self, "Error", resp.text)
+
+    # ------------------------------------------------------------------
+    def test(self) -> None:
+        if self._client.is_local():
+            try:
+                from app import config
+                from sqlmodel import Session
+
+                with Session(config.engine) as sess:
+                    sess.exec(text("SELECT 1"))
+                self.status.setStyleSheet("color: green")
+                self.status.setText("OK")
+            except Exception as exc:  # pragma: no cover - debug helper
+                self.status.setStyleSheet("color: red")
+                self.status.setText(str(exc))
+        else:
+            resp = self._client.get("/health")
+            if resp.status_code == 200:
+                self.status.setStyleSheet("color: green")
+                self.status.setText("OK")
+            else:
+                self.status.setStyleSheet("color: red")
+                self.status.setText(resp.text)

--- a/gui/widgets/quick_actions.py
+++ b/gui/widgets/quick_actions.py
@@ -1,0 +1,104 @@
+"""Quick actions panel."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import QPushButton, QVBoxLayout, QWidget
+
+from ..api_client import BaseClient
+from ..util import qt
+
+
+class QuickActions(QWidget):
+    """Common helper tasks like imports and exports."""
+
+    def __init__(self, client: BaseClient) -> None:
+        super().__init__()
+        self._client = client
+
+        layout = QVBoxLayout(self)
+        imp_btn = QPushButton("Import BOM…")
+        imp_btn.clicked.connect(self.import_bom)
+        layout.addWidget(imp_btn)
+
+        seed_btn = QPushButton("Seed Sample Data")
+        seed_btn.clicked.connect(self.seed_sample)
+        layout.addWidget(seed_btn)
+
+        exp_btn = QPushButton("Open exports folder…")
+        exp_btn.clicked.connect(self.export_files)
+        layout.addWidget(exp_btn)
+        layout.addStretch(1)
+
+    # ------------------------------------------------------------------
+    def set_client(self, client: BaseClient) -> None:
+        self._client = client
+
+    # ------------------------------------------------------------------
+    def import_bom(self) -> None:
+        path = qt.pick_file(self, "Import BOM", "BOM Files (*.csv *.xlsx)")
+        if not path:
+            return
+        try:
+            with open(path, "rb") as f:
+                resp = self._client.post("/bom/import", files={"file": (Path(path).name, f)})
+        except OSError as exc:  # pragma: no cover - user path
+            qt.error(self, "Import", str(exc))
+            return
+        if resp.status_code == 200:
+            qt.alert(self, "Import", "Done")
+        else:
+            qt.error(self, "Import", resp.text)
+
+    # ------------------------------------------------------------------
+    def seed_sample(self) -> None:
+        tpl = Path("bom_template.csv")
+        if not tpl.exists():
+            resp = self._client.get("/bom/template")
+            if resp.status_code == 200:
+                tpl.write_bytes(resp.content)
+            else:
+                qt.error(self, "Seed", "Template download failed")
+                return
+        resp = self._client.post("/customers/", json={"name": "Sample"})
+        if resp.status_code != 200:
+            qt.error(self, "Seed", resp.text)
+            return
+        cust_id = resp.json().get("id")
+        resp = self._client.post(
+            "/projects/", json={"name": "Sample Project", "customer_id": cust_id}
+        )
+        if resp.status_code != 200:
+            qt.error(self, "Seed", resp.text)
+            return
+        project_id = resp.json().get("id")
+        with open(tpl, "rb") as f:
+            resp = self._client.request(
+                "POST",
+                "/bom/import",
+                files={"file": (tpl.name, f)},
+                params={"project_id": project_id},
+            )
+        if resp.status_code == 200:
+            qt.alert(self, "Seed", "Seeded")
+        else:
+            qt.error(self, "Seed", resp.text)
+
+    # ------------------------------------------------------------------
+    def export_files(self) -> None:
+        path = qt.save_file(self, "Save BOM CSV", "CSV Files (*.csv)")
+        if path:
+            resp = self._client.get("/export/bom.csv")
+            if resp.status_code == 200:
+                Path(path).write_bytes(resp.content)
+            else:
+                qt.error(self, "Export", resp.text)
+        path = qt.save_file(self, "Save Test Results", "Excel Files (*.xlsx)")
+        if path:
+            resp = self._client.get("/export/testresults.xlsx")
+            if resp.status_code == 200:
+                Path(path).write_bytes(resp.content)
+            else:
+                qt.error(self, "Export", resp.text)
+        qt.alert(self, "Export", "Done")

--- a/gui/widgets/server_panel.py
+++ b/gui/widgets/server_panel.py
@@ -1,0 +1,114 @@
+"""Embedded uvicorn server controller."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtCore import QProcess, QProcessEnvironment, Signal
+from PySide6.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QPlainTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+from PySide6.QtGui import QGuiApplication
+
+
+class ServerPanel(QWidget):
+    """Start/stop a uvicorn subprocess and show logs."""
+
+    base_url_changed = Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proc: QProcess | None = None
+
+        layout = QVBoxLayout(self)
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Host:"))
+        self.host_edit = QLineEdit("127.0.0.1")
+        row.addWidget(self.host_edit)
+        row.addWidget(QLabel("Port:"))
+        self.port_edit = QLineEdit("8000")
+        row.addWidget(self.port_edit)
+        row.addWidget(QLabel("Env:"))
+        self.env_combo = QComboBox()
+        self.env_combo.addItems(["prod", "dev"])
+        row.addWidget(self.env_combo)
+        copy_btn = QPushButton("Copy base URL")
+        copy_btn.clicked.connect(self.copy_url)
+        row.addWidget(copy_btn)
+        layout.addLayout(row)
+
+        btn_row = QHBoxLayout()
+        self.start_btn = QPushButton("Start")
+        self.start_btn.clicked.connect(self.start_server)
+        btn_row.addWidget(self.start_btn)
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.clicked.connect(self.stop_server)
+        self.stop_btn.setEnabled(False)
+        btn_row.addWidget(self.stop_btn)
+        layout.addLayout(btn_row)
+
+        self.log_view = QPlainTextEdit()
+        self.log_view.setReadOnly(True)
+        layout.addWidget(self.log_view)
+
+    # ------------------------------------------------------------------
+    def set_enabled(self, enabled: bool) -> None:
+        self.start_btn.setEnabled(enabled and self.proc is None)
+        if not enabled:
+            self.stop_server()
+
+    # ------------------------------------------------------------------
+    def start_server(self) -> None:
+        if self.proc is not None:
+            return
+        host = self.host_edit.text() or "127.0.0.1"
+        port = self.port_edit.text() or "8000"
+        env = QProcessEnvironment.systemEnvironment()
+        env.insert("BOM_ENV", self.env_combo.currentText())
+        self.proc = QProcess(self)
+        self.proc.setProcessEnvironment(env)
+        self.proc.setProcessChannelMode(QProcess.ProcessChannelMode.MergedChannels)
+        self.proc.readyRead.connect(self._read_output)
+        self.proc.start(
+            sys.executable,
+            ["-m", "uvicorn", "app.main:app", "--host", host, "--port", port]
+        )
+        self.start_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+        self.base_url_changed.emit(f"http://{host}:{port}")
+
+    # ------------------------------------------------------------------
+    def stop_server(self) -> None:
+        if self.proc is None:
+            return
+        self.proc.terminate()
+        self.proc.waitForFinished(3000)
+        if self.proc.state() != QProcess.NotRunning:
+            self.proc.kill()
+            self.proc.waitForFinished(1000)
+        self.proc = None
+        self.start_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+
+    # ------------------------------------------------------------------
+    def _read_output(self) -> None:  # pragma: no cover - Qt callback
+        if self.proc:
+            data = bytes(self.proc.readAll()).decode("utf-8", "ignore")
+            self.log_view.appendPlainText(data.rstrip())
+
+    # ------------------------------------------------------------------
+    def copy_url(self) -> None:
+        url = f"http://{self.host_edit.text() or '127.0.0.1'}:{self.port_edit.text() or '8000'}"
+        QGuiApplication.clipboard().setText(url)
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:  # pragma: no cover - cleanup
+        self.stop_server()
+        super().close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ full = [
     "xlrd",
     "apscheduler",
     "requests",
+    "httpx",
+    "PySide6",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ requests_html
 pillow
 toml
 reportlab
+PySide6

--- a/scripts/launch_gui.bat
+++ b/scripts/launch_gui.bat
@@ -1,0 +1,3 @@
+@echo off
+python -m pip install -e .[full]
+bom-gui

--- a/scripts/launch_gui.sh
+++ b/scripts/launch_gui.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+python -m pip install -e .[full]
+bom-gui

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,21 +1,17 @@
-# root: tests/test_gui.py
 import os
-import tkinter as tk
+
 import pytest
 
-pytest.importorskip('tkinter')
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-if not os.environ.get('DISPLAY'):
-    pytest.skip('GUI tests require a display', allow_module_level=True)
+from PySide6 import QtWidgets
 
 from gui import control_center
 
 
 def test_build_ui_widgets():
-    root = tk.Tk()
-    try:
-        ui = control_center.build_ui(root)
-        widgets = root.winfo_children()
-        assert widgets, 'no widgets created'
-    finally:
-        root.destroy()
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    ui = control_center.ControlCenter()
+    assert ui.tabs.count() >= 1
+    ui.close()
+    app.quit()

--- a/tests/test_gui_tabs.py
+++ b/tests/test_gui_tabs.py
@@ -1,120 +1,52 @@
-import types
-import sys
 import os
-import importlib
-from pathlib import Path
+import types
 
 import pytest
 
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PySide6 import QtWidgets
 
-def stub_tk_module():
-    class Widget:
-        def __init__(self, *a, **k):
-            self.tk = self
-            self.children = {}
-            self._data = {}
-            self._data.update(k)
-        def pack(self, *a, **k):
-            pass
-        def grid(self, *a, **k):
-            pass
-        def insert(self, *a, **k):
-            pass
-        def configure(self, *a, **k):
-            pass
-        def destroy(self):
-            pass
-        def winfo_children(self):
-            return []
-        def heading(self, *a, **k):
-            pass
-        def get_children(self):
-            return []
-        def __getitem__(self, key):
-            return self._data.get(key)
-        def __setitem__(self, key, value):
-            self._data[key] = value
-
-    class Root(Widget):
-        def __init__(self, *a, **k):
-            super().__init__(*a, **k)
-            self._last_child_ids = {}
-            self._w = '.'
-
-    class StringVar:
-        def __init__(self, *a, **k):
-            self.value = k.get('value')
-
-    stub = types.SimpleNamespace(
-        Tk=Root,
-        Frame=Widget,
-        Misc=Widget,
-        Label=Widget,
-        Button=Widget,
-        Entry=Widget,
-        LabelFrame=Widget,
-        Radiobutton=Widget,
-        Text=Widget,
-        StringVar=StringVar,
-        Toplevel=Widget,
-        messagebox=types.SimpleNamespace(showinfo=lambda *a, **k: None, showerror=lambda *a, **k: None, askyesno=lambda *a, **k: True),
-        filedialog=types.SimpleNamespace(askopenfilename=lambda *a, **k: '', asksaveasfilename=lambda *a, **k: ''),
-    )
-    stub.scrolledtext = types.SimpleNamespace(ScrolledText=Widget)
-    stub.ttk = types.SimpleNamespace(Notebook=Widget, Treeview=Widget)
-    return stub
+from gui.widgets.auth_panel import AuthPanel
+from gui.widgets.db_panel import DBPanel
+from gui.widgets.quick_actions import QuickActions
+from gui.widgets.server_panel import ServerPanel
 
 
-def import_gui_with_stub(monkeypatch):
-    monkeypatch.setenv('BOM_NO_REEXEC', '1')
-    import sys
-    from pathlib import Path
-    repo = Path(__file__).resolve().parents[1]
-    if str(repo) not in sys.path:
-        sys.path.insert(0, str(repo))
-    tk_stub = stub_tk_module()
-    monkeypatch.setitem(sys.modules, 'tkinter', tk_stub)
-    monkeypatch.setitem(sys.modules, 'tkinter.ttk', tk_stub.ttk)
-    monkeypatch.setitem(sys.modules, 'tkinter.scrolledtext', tk_stub.scrolledtext)
-    import importlib
-    cc = importlib.reload(importlib.import_module('gui.control_center'))
-    monkeypatch.setattr(cc, 'requests', types.SimpleNamespace(get=lambda *a, **k: types.SimpleNamespace(status_code=200, json=lambda: []), post=lambda *a, **k: types.SimpleNamespace(status_code=200, json=lambda: {})))
-    cc.BOMItemsTab.refresh = lambda self: None
-    cc.TestResultsTab.refresh = lambda self: None
-    cc.QuoteTab.refresh = lambda self: None
-    cc.TraceabilityTab.query_board = lambda self: None
-    cc.TraceabilityTab.query_component = lambda self: None
-    cc.TOKEN = "test"
-    return cc
+class DummyClient:
+    def __init__(self):
+        self._token = None
+
+    def set_token(self, token):
+        self._token = token
+
+    def get(self, path, params=None):
+        if path == "/ui/settings":
+            return types.SimpleNamespace(status_code=200, json=lambda: {"database_url": "sqlite://"})
+        if path == "/auth/me":
+            return types.SimpleNamespace(status_code=200, json=lambda: {"username": "u", "role": "r"})
+        return types.SimpleNamespace(status_code=200, json=lambda: {})
+
+    def post(self, path, json=None, files=None):
+        if path == "/auth/token":
+            return types.SimpleNamespace(status_code=200, json=lambda: {"access_token": "t"})
+        return types.SimpleNamespace(status_code=200, json=lambda: {})
+
+    def is_local(self):
+        return True
 
 
-def test_tab_classes_instantiation(monkeypatch):
-    cc = import_gui_with_stub(monkeypatch)
-    root = cc.tk.Tk()
-    for cls in [
-        cc.ServerTab,
-        cc.BOMItemsTab,
-        cc.ImportPDFTab,
-        cc.QuoteTab,
-        cc.TestResultsTab,
-        cc.TraceabilityTab,
-        cc.ExportTab,
-        cc.UsersTab,
-        cc.SettingsTab,
-    ]:
-        cls(root)
+panels = [
+    lambda: AuthPanel(DummyClient()),
+    lambda: DBPanel(DummyClient()),
+    lambda: QuickActions(DummyClient()),
+    lambda: ServerPanel(),
+]
 
 
-def test_autovenv_reexec(monkeypatch, tmp_path):
-    cc = import_gui_with_stub(monkeypatch)
-    monkeypatch.setattr(sys, 'prefix', '/usr')
-    monkeypatch.setattr(sys, 'base_prefix', '/usr')
-    vpy = Path('.venv') / ('Scripts' if os.name == 'nt' else 'bin') / ('python.exe' if os.name == 'nt' else 'python')
-    vpy.parent.mkdir(parents=True, exist_ok=True)
-    vpy.write_text('')
-    called = {}
-    monkeypatch.setattr(os, 'execv', lambda exe, args: called.setdefault('exe', exe))
-    monkeypatch.delenv('BOM_NO_REEXEC', raising=False)
-    cc._reexec_into_venv()
-    assert called['exe'] == str(vpy.resolve())
-
+@pytest.mark.parametrize("factory", panels)
+def test_panel_classes_instantiation(factory):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    w = factory()
+    assert isinstance(w, QtWidgets.QWidget)
+    w.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- replace old Tk debug tool with a modular PySide6 control center
- add HTTP/local API clients and basic auth, DB and playground panels
- wire up GUI tests and document new dependencies
- allow form-encoded payloads in API clients and make DB panel read-only when using HTTP backend

## Testing
- `PYTHONPATH=. pytest tests/test_gui.py tests/test_gui_tabs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a814bb38832c99d5ca05abf2c86d