### PR TITLE
Use direct module call for GUI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Install the optional GUI dependencies and launch:
 
 ```bash
 python -m pip install -e .[full]
-bom-gui
+python -m gui.control_center
 ```
 
 Use **Backend = Local** for an in-memory API or switch to **HTTP** to talk to a running server.

--- a/scripts/launch_gui.bat
+++ b/scripts/launch_gui.bat
@@ -1,3 +1,3 @@
 @echo off
 python -m pip install -e .[full]
-bom-gui
+python -m gui.control_center

--- a/scripts/launch_gui.sh
+++ b/scripts/launch_gui.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 python -m pip install -e .[full]
-bom-gui
+python -m gui.control_center


### PR DESCRIPTION
## Summary
- run `gui.control_center` directly in launch scripts
- document the new launch command in the README

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6899cb701c3c832c82a702cf82f30e02