### PR TITLE
Use direct module call for GUI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,11 @@ Install the optional GUI dependencies and launch:
 
 ```bash
 python -m pip install -e .[full]
-bom-gui
+python -m gui.control_center
 ```
+
+If Python reports `ModuleNotFoundError: No module named 'PySide6'`,
+rerun the installation step to pull in the GUI dependencies.
 
 Use **Backend = Local** for an in-memory API or switch to **HTTP** to talk to a running server.
 Tabs include Quick Actions (import/seed/export helpers), Auth, DB settings, an HTTP playground and an optional Server controller.

--- a/gui/control_center.py
+++ b/gui/control_center.py
@@ -11,18 +11,24 @@ import os
 import sys
 from pathlib import Path
 
-from PySide6.QtWidgets import (
-    QApplication,
-    QComboBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QMainWindow,
-    QPushButton,
-    QTabWidget,
-    QVBoxLayout,
-    QWidget,
-)
+try:  # Provide a helpful error if PySide6 is missing
+    from PySide6.QtWidgets import (
+        QApplication,
+        QComboBox,
+        QHBoxLayout,
+        QLabel,
+        QLineEdit,
+        QMainWindow,
+        QPushButton,
+        QTabWidget,
+        QVBoxLayout,
+        QWidget,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ModuleNotFoundError(
+        "PySide6 is required to run the GUI. Install it with"
+        " `python -m pip install -e .[full]`."
+    ) from exc
 
 from .api_client import HTTPClient, LocalClient, BaseClient
 from .widgets.auth_panel import AuthPanel

--- a/scripts/launch_gui.bat
+++ b/scripts/launch_gui.bat
@@ -1,3 +1,3 @@
 @echo off
 python -m pip install -e .[full]
-bom-gui
+python -m gui.control_center

--- a/scripts/launch_gui.sh
+++ b/scripts/launch_gui.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 python -m pip install -e .[full]
-bom-gui
+python -m gui.control_center


### PR DESCRIPTION
## Summary
- run `gui.control_center` directly in launch scripts
- document the new launch command and how to resolve missing PySide6
- provide a clear import error if PySide6 is absent

## Testing
- `pytest` *(fails: segmentation fault after `tests/test_pdf_import.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6899cb701c3c832c82a702cf82f30e02