### PR TITLE
Fix SQLite timestamp default migrations and quote identifiers

### DIFF
--- a/tests/test_db_safe_migrate.py
+++ b/tests/test_db_safe_migrate.py
@@ -1,19 +1,39 @@
 import sqlalchemy
-from sqlalchemy import text
+from sqlalchemy import inspect, text
 from sqlmodel import create_engine
 
 from app.db_safe_migrate import run_sqlite_safe_migrations
 
 
-def test_run_sqlite_safe_migrations_adds_created_at():
+def test_created_at_added_and_backfilled():
     engine = create_engine(
         "sqlite://",
         connect_args={"check_same_thread": False},
         poolclass=sqlalchemy.pool.StaticPool,
     )
     with engine.begin() as conn:
-        conn.execute(text("CREATE TABLE customer (id INTEGER PRIMARY KEY, name TEXT)"))
+        conn.execute(text('CREATE TABLE "customer" (id INTEGER PRIMARY KEY, name TEXT)'))
+        conn.execute(text('INSERT INTO "customer"(name) VALUES ("A"), ("B")'))
     run_sqlite_safe_migrations(engine)
-    insp = sqlalchemy.inspect(engine)
+    insp = inspect(engine)
     cols = {c["name"] for c in insp.get_columns("customer")}
     assert "created_at" in cols
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text('SELECT COUNT(*) FROM "customer" WHERE "created_at" IS NULL')
+        ).scalar()
+        assert rows == 0
+
+
+def test_reserved_name_user_table():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=sqlalchemy.pool.StaticPool,
+    )
+    with engine.begin() as conn:
+        conn.execute(text('CREATE TABLE "user" (id INTEGER PRIMARY KEY, name TEXT)'))
+    run_sqlite_safe_migrations(engine)
+    insp = inspect(engine)
+    cols = {c["name"] for c in insp.get_columns("user")}
+    assert "hashed_pw" in cols


### PR DESCRIPTION
## Summary
- handle SQLite DEFAULT CURRENT_TIMESTAMP by stripping the default and backfilling
- quote table and column names in raw SQL
- add tests for timestamp migration/backfill and reserved name handling

## Testing
- `pytest tests/test_db_safe_migrate.py`
- `python -m app.tools.db migrate`


------
https://chatgpt.com/codex/tasks/task_e_68aace872d1c832cb5292738a74b1660