### PR TITLE
Expand SQLite safe migrations

### DIFF
--- a/app/db_safe_migrate.py
+++ b/app/db_safe_migrate.py
@@ -17,16 +17,33 @@ _MIGRATIONS: dict[str, dict[str, str]] = {
     },
     "project": {
         "code": "TEXT DEFAULT ''",
+        "title": "TEXT DEFAULT ''",
+        "status": "TEXT DEFAULT 'draft'",
+        "priority": "TEXT DEFAULT 'med'",
+        "notes": "TEXT DEFAULT ''",
+        "created_at": "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
+        "due_at": "TIMESTAMP",
+    },
+    "assembly": {
+        "rev": "TEXT DEFAULT ''",
         "notes": "TEXT DEFAULT ''",
         "created_at": "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
     },
-    "assembly": {
-        "created_at": "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
-    },
     "part": {
+        "description": "TEXT DEFAULT ''",
+        "package": "TEXT DEFAULT ''",
+        "value": "TEXT DEFAULT ''",
+        "function": "TEXT DEFAULT ''",
+        "active_passive": "TEXT DEFAULT ''",
+        "power_required": "INTEGER DEFAULT 0",
+        "datasheet_url": "TEXT DEFAULT ''",
         "created_at": "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
     },
     "task": {
+        "title": "TEXT DEFAULT ''",
+        "description": "TEXT DEFAULT ''",
+        "status": "TEXT DEFAULT 'todo'",
+        "assigned_to": "TEXT",
         "created_at": "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
     },
     "bomitem": {


### PR DESCRIPTION
## Summary
- extend SQLite safe migrations map to cover all project, assembly, part, task, and related columns
- keep timestamp default workaround and double-quoted identifier handling
- add tests verifying project columns are added and backfilled

## Testing
- `python -m app.tools.db migrate`
- `pytest tests/test_db_safe_migrate.py::test_created_at_added_and_backfilled -q`
- `pytest tests/test_db_safe_migrate.py::test_project_columns_added -q`
- `pytest tests/test_db_safe_migrate.py::test_reserved_name_user_table -q`
- `pytest tests/test_db_safe_migrate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae48041d4832c9bf25b9cb2b232a1