### PR TITLE
Add cascading deletes and BOM import GUI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Steps:
 3. Select an assembly and upload a BOM CSV.
 4. Review the import report, BOM items and any tasks created for unknown parts.
 
+Right-click or use the Delete buttons to remove Customers, Projects or Assemblies. If
+a Customer or Project has children, the GUI will prompt to cascade-delete.
+
+Use **Import BOM** on an Assembly to load a CSV with the strict header. The dialog
+reports matched/unmatched counts and any created task IDs.
+
 ## Debug GUI
 
 Launch the optional Qt-based debug GUI to explore the API locally. The

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -8,9 +8,14 @@ The modules re-export the most commonly used functions so existing imports
 like ``from app.services import import_bom`` continue to work.
 """
 
-from .customers import list_customers, create_customer
-from .projects import list_projects, create_project
-from .assemblies import list_assemblies, create_assembly
+from .customers import (
+    list_customers,
+    create_customer,
+    delete_customer,
+    DeleteBlockedError,
+)
+from .projects import list_projects, create_project, delete_project
+from .assemblies import list_assemblies, create_assembly, delete_assembly
 from .tasks import list_tasks
 from .bom_import import ImportReport, validate_headers, import_bom
 
@@ -19,8 +24,12 @@ __all__ = [
     "create_customer",
     "list_projects",
     "create_project",
+    "delete_project",
     "list_assemblies",
     "create_assembly",
+    "delete_assembly",
+    "delete_customer",
+    "DeleteBlockedError",
     "list_tasks",
     "ImportReport",
     "validate_headers",

--- a/app/services/assemblies.py
+++ b/app/services/assemblies.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from sqlmodel import Session, select
 
-from ..models import Assembly
+from ..models import Assembly, BOMItem
 
 
 def list_assemblies(project_id: int, session: Session) -> List[Assembly]:
@@ -27,4 +27,16 @@ def create_assembly(
     session.commit()
     session.refresh(asm)
     return asm
+
+
+def delete_assembly(assembly_id: int, session: Session) -> None:
+    """Delete an assembly along with its BOM items."""
+
+    asm = session.get(Assembly, assembly_id)
+    if not asm:
+        return
+
+    session.exec(BOMItem.__table__.delete().where(BOMItem.assembly_id == assembly_id))
+    session.delete(asm)
+    session.commit()
 

--- a/tests/test_services_delete.py
+++ b/tests/test_services_delete.py
@@ -1,0 +1,74 @@
+from importlib import reload
+
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session, create_engine, select
+
+import app.models as models
+from app.models import Customer, Project, Assembly, BOMItem, Task
+from app.services import (
+    create_customer,
+    create_project,
+    create_assembly,
+    delete_customer,
+    delete_project,
+    DeleteBlockedError,
+)
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite://",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.clear()
+    reload(models)
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def populate(session: Session):
+    cust = create_customer("Acme", None, session)
+    proj = create_project(cust.id, "PRJ", "Project", "med", None, session)
+    asm = create_assembly(proj.id, "A", None, session)
+    session.add(BOMItem(assembly_id=asm.id, reference="R1", qty=1))
+    session.add(Task(project_id=proj.id, title="t1"))
+    session.commit()
+    return cust, proj, asm
+
+
+def test_delete_customer_cascade_blocked():
+    engine = setup_db()
+    with Session(engine) as session:
+        cust, proj, asm = populate(session)
+        try:
+            delete_customer(cust.id, session)
+        except DeleteBlockedError:
+            pass
+        else:
+            assert False, "expected DeleteBlockedError"
+
+
+def test_delete_customer_cascade_success():
+    engine = setup_db()
+    with Session(engine) as session:
+        cust, proj, asm = populate(session)
+        delete_customer(cust.id, session, cascade=True)
+        assert session.exec(select(Customer)).all() == []
+        assert session.exec(select(Project)).all() == []
+        assert session.exec(select(Assembly)).all() == []
+        assert session.exec(select(BOMItem)).all() == []
+        assert session.exec(select(Task)).all() == []
+
+
+def test_delete_project_cascade_success():
+    engine = setup_db()
+    with Session(engine) as session:
+        cust, proj, asm = populate(session)
+        delete_project(proj.id, session, cascade=True)
+        assert session.get(Customer, cust.id) is not None
+        assert session.exec(select(Project)).all() == []
+        assert session.exec(select(Assembly)).all() == []
+        assert session.exec(select(BOMItem)).all() == []
+        assert session.exec(select(Task)).all() == []


### PR DESCRIPTION
## Summary
- add service helpers for deleting customers, projects and assemblies safely with optional cascade
- wire delete buttons and BOM import workflow in Qt GUI
- document GUI delete and BOM import actions

## Testing
- `pytest tests/test_services_delete.py tests/test_services_crud.py tests/test_services_customers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaefa44734832c9eb163bb840cc2ad