### PR TITLE
Fix Import BOM signal and worker safety

### DIFF
--- a/app/gui/state.py
+++ b/app/gui/state.py
@@ -24,7 +24,8 @@ def get_session() -> Session:
 
 
 class _Worker(QThread):
-    """Simple thread worker executing ``fn`` and emitting ``finished``."""
+    """Simple thread worker executing ``fn`` and emitting ``finished``
+    with either the result or any raised exception."""
 
     finished = pyqtSignal(object)
 
@@ -37,8 +38,8 @@ class _Worker(QThread):
     def run(self) -> None:  # pragma: no cover - Qt thread
         try:
             result = self._fn(*self._args, **self._kwargs)
-        except Exception as exc:  # pragma: no cover - propagate errors
-            result = exc
+        except Exception as e:
+            result = e
         self.finished.emit(result)
 
 


### PR DESCRIPTION
## Summary
- route BOM import through AppState.import_bom and bomImported signal
- harden worker thread to emit exceptions and document behavior
- guard table selection handlers against empty rows

## Testing
- `pytest tests/test_bom_import.py::test_bom_import_creates_items_and_tasks -q`
- `pytest tests/test_auth.py::test_admin_seed_and_auth -q`
- `pytest tests/test_project_csv.py::test_project_csv -q` *(fails: KeyError: 'access_token')*

------
https://chatgpt.com/codex/tasks/task_e_68ac1acc89f4832ca9d4db0f628a5b1d