### PR TITLE
Add BOM classification editor and services

### DIFF
--- a/app/gui/bom_editor_pane.py
+++ b/app/gui/bom_editor_pane.py
@@ -1,0 +1,229 @@
+"""BOM editor for classifying parts as active or passive."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from PyQt6.QtCore import Qt, QSortFilterProxyModel, QSettings, pyqtSignal
+from PyQt6.QtGui import QStandardItemModel, QStandardItem
+from PyQt6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QToolBar,
+    QLineEdit,
+    QToolButton,
+    QMenu,
+    QAction,
+    QTableView,
+    QStyledItemDelegate,
+    QComboBox,
+    QMessageBox,
+)
+
+from .. import services
+from . import state as app_state
+
+
+PartIdRole = Qt.ItemDataRole.UserRole + 1
+
+
+class BOMFilterProxy(QSortFilterProxyModel):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._filter = ""
+
+    def setFilterString(self, text: str) -> None:
+        self._filter = text.lower()
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent):  # pragma: no cover - Qt glue
+        if not self._filter:
+            return True
+        model = self.sourceModel()
+        for col in range(4):  # PN, Reference, Description, Manufacturer
+            idx = model.index(source_row, col, source_parent)
+            data = model.data(idx)
+            if data and self._filter in str(data).lower():
+                return True
+        return False
+
+
+class ActivePassiveDelegate(QStyledItemDelegate):
+    valueChanged = pyqtSignal(int, str)  # part_id, new_value
+
+    def createEditor(self, parent, option, index):  # pragma: no cover - UI glue
+        combo = QComboBox(parent)
+        combo.addItems(["active", "passive"])
+        part_id = index.data(PartIdRole)
+
+        def _on_change(value: str) -> None:
+            self.commitData.emit(combo)
+            self.closeEditor.emit(combo, QStyledItemDelegate.NoHint)
+            self.valueChanged.emit(part_id, value)
+
+        combo.currentTextChanged.connect(_on_change)
+        return combo
+
+    def setEditorData(self, editor, index):  # pragma: no cover - UI glue
+        editor.setCurrentText(index.data() or "passive")
+
+    def setModelData(self, editor, model, index):  # pragma: no cover - UI glue
+        model.setData(index, editor.currentText())
+
+
+class BOMEditorPane(QWidget):
+    """Widget presenting BOM items with active/passive classification."""
+
+    def __init__(self, assembly_id: int, parent=None) -> None:
+        super().__init__(parent)
+        self._assembly_id = assembly_id
+        self._settings = QSettings("BOM_DB", f"BOMEditorPane/{assembly_id}")
+        self._dirty: Dict[int, str] = {}
+        self._parts_state: Dict[int, str] = {}
+
+        layout = QVBoxLayout(self)
+        self.toolbar = QToolBar()
+        layout.addWidget(self.toolbar)
+
+        # Filter
+        self.filter_edit = QLineEdit()
+        self.filter_edit.setPlaceholderText("Filter…")
+        self.toolbar.addWidget(self.filter_edit)
+
+        # Columns button
+        self.columns_btn = QToolButton()
+        self.columns_btn.setText("Columns")
+        self.columns_menu = QMenu(self)
+        self.columns_btn.setMenu(self.columns_menu)
+        self.columns_btn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.toolbar.addWidget(self.columns_btn)
+
+        # Apply immediately toggle
+        self.apply_act = QAction("Apply Immediately", self)
+        self.apply_act.setCheckable(True)
+        self.toolbar.addAction(self.apply_act)
+
+        # Save button
+        self.save_act = QAction("Save", self)
+        self.save_act.setEnabled(False)
+        self.toolbar.addAction(self.save_act)
+
+        # Table
+        self.table = QTableView()
+        layout.addWidget(self.table)
+        self.model = QStandardItemModel(0, 5, self)
+        self.model.setHorizontalHeaderLabels(
+            ["PN", "Reference", "Description", "Manufacturer", "Active/Passive"]
+        )
+        self.proxy = BOMFilterProxy(self)
+        self.proxy.setSourceModel(self.model)
+        self.table.setModel(self.proxy)
+        self.table.setAlternatingRowColors(True)
+
+        # Delegate
+        self.delegate = ActivePassiveDelegate(self.table)
+        self.delegate.valueChanged.connect(self._on_value_changed)
+        self.table.setItemDelegateForColumn(4, self.delegate)
+
+        self.filter_edit.textChanged.connect(self.proxy.setFilterString)
+        self.apply_act.toggled.connect(self._on_apply_toggled)
+        self.save_act.triggered.connect(self._save_changes)
+
+        self._setup_columns_menu()
+        self._load_data()
+
+    # ------------------------------------------------------------------
+    def _setup_columns_menu(self) -> None:
+        self._column_actions: list[QAction] = []
+        for idx, name in enumerate(
+            ["PN", "Reference", "Description", "Manufacturer", "Active/Passive"]
+        ):
+            act = QAction(name, self)
+            act.setCheckable(True)
+            visible = self._settings.value(f"col{idx}_visible", True, type=bool)
+            act.setChecked(visible)
+            act.toggled.connect(lambda checked, col=idx: self.table.setColumnHidden(col, not checked))
+            self.columns_menu.addAction(act)
+            self._column_actions.append(act)
+            self.table.setColumnHidden(idx, not visible)
+            width = self._settings.value(f"col{idx}_width", type=int)
+            if width:
+                self.table.setColumnWidth(idx, int(width))
+
+    def _load_data(self) -> None:
+        with app_state.get_session() as session:
+            rows = services.get_joined_bom_for_assembly(session, self._assembly_id)
+        self.model.setRowCount(0)
+        for r in rows:
+            items = [
+                QStandardItem(r.part_number),
+                QStandardItem(r.reference),
+                QStandardItem(r.description or ""),
+                QStandardItem(r.manufacturer or ""),
+                QStandardItem(r.active_passive),
+            ]
+            for i, it in enumerate(items):
+                it.setEditable(i == 4)
+                it.setData(r.part_id, PartIdRole)
+            self.model.appendRow(items)
+            self._parts_state[r.part_id] = r.active_passive
+
+    # ------------------------------------------------------------------
+    def _on_value_changed(self, part_id: int, value: str) -> None:
+        old_value = self._parts_state.get(part_id, "passive")
+        # update all rows with this part_id
+        for row in range(self.model.rowCount()):
+            idx0 = self.model.index(row, 0)
+            pid = self.model.data(idx0, PartIdRole)
+            if pid == part_id:
+                self.model.setData(self.model.index(row, 4), value)
+        if self.apply_act.isChecked():
+            try:
+                with app_state.get_session() as session:
+                    services.update_part_active_passive(session, part_id, value)
+            except Exception as exc:  # pragma: no cover - depends on DB
+                QMessageBox.warning(self, "Update failed", str(exc))
+                # revert
+                for row in range(self.model.rowCount()):
+                    if self.model.data(self.model.index(row, 0), PartIdRole) == part_id:
+                        self.model.setData(self.model.index(row, 4), old_value)
+                return
+            self._parts_state[part_id] = value
+        else:
+            self._dirty[part_id] = value
+            self.save_act.setEnabled(True)
+
+    def _on_apply_toggled(self, checked: bool) -> None:
+        if checked and self._dirty:
+            self._save_changes()
+
+    def _save_changes(self) -> None:
+        if not self._dirty:
+            return
+        failures = []
+        for part_id, value in list(self._dirty.items()):
+            try:
+                with app_state.get_session() as session:
+                    services.update_part_active_passive(session, part_id, value)
+            except Exception as exc:
+                failures.append(str(exc))
+                # revert
+                old_val = self._parts_state.get(part_id, "passive")
+                for row in range(self.model.rowCount()):
+                    if self.model.data(self.model.index(row, 0), PartIdRole) == part_id:
+                        self.model.setData(self.model.index(row, 4), old_val)
+            else:
+                self._parts_state[part_id] = value
+                del self._dirty[part_id]
+        if failures:
+            QMessageBox.warning(self, "Save failed", "; ".join(failures))
+        else:
+            QMessageBox.information(self, "Saved", "Changes saved.")
+        self.save_act.setEnabled(bool(self._dirty))
+
+    # ------------------------------------------------------------------
+    def closeEvent(self, event) -> None:  # pragma: no cover - UI glue
+        for idx, act in enumerate(self._column_actions):
+            self._settings.setValue(f"col{idx}_visible", act.isChecked())
+            self._settings.setValue(f"col{idx}_width", self.table.columnWidth(idx))
+        super().closeEvent(event)

--- a/app/gui/widgets.py
+++ b/app/gui/widgets.py
@@ -514,6 +514,10 @@ class AssembliesPane(QWidget):
                 self._project_id, self.status_filter.currentText()
             )
 
+    def current_assembly_id(self) -> int | None:
+        """Return the currently selected assembly id."""
+        return self._assembly_id
+
     def create_assembly(self) -> None:  # pragma: no cover - UI glue
         if self._project_id is None:
             return

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -38,6 +38,8 @@ from .projects import list_projects, create_project, delete_project
 from .assemblies import list_assemblies, list_bom_items, create_assembly, delete_assembly
 from .tasks import list_tasks
 from .bom_import import ImportReport, validate_headers, import_bom
+from .bom_read_models import JoinedBOMRow, get_joined_bom_for_assembly
+from .parts import update_part_active_passive
 
 __all__ = [
     "list_customers",
@@ -56,5 +58,8 @@ __all__ = [
     "ImportReport",
     "validate_headers",
     "import_bom",
+    "JoinedBOMRow",
+    "get_joined_bom_for_assembly",
+    "update_part_active_passive",
 ]
 

--- a/app/services/bom_read_models.py
+++ b/app/services/bom_read_models.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import List, Literal
+import re
+
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from ..models import BOMItem, Part, PartType
+
+# Regex for natural sort
+_token = re.compile(r"(\d+)")
+
+def natural_key(s: str) -> list[object]:
+    return [int(t) if t.isdigit() else t.lower() for t in _token.split(s)]
+
+
+class JoinedBOMRow(BaseModel):
+    bom_item_id: int
+    part_id: int
+    part_number: str
+    reference: str
+    qty: int
+    description: str | None
+    manufacturer: str | None
+    active_passive: Literal["active", "passive"]
+
+
+def get_joined_bom_for_assembly(session: Session, assembly_id: int) -> List[JoinedBOMRow]:
+    """Return joined BOM items with part data for an assembly."""
+
+    stmt = (
+        select(BOMItem, Part)
+        .join(Part, Part.id == BOMItem.part_id)
+        .where(BOMItem.assembly_id == assembly_id)
+    )
+    rows = session.exec(stmt).all()
+    result: List[JoinedBOMRow] = []
+    for item, part in rows:
+        ap = part.active_passive.value if isinstance(part.active_passive, PartType) else part.active_passive
+        ap = ap or PartType.passive.value
+        result.append(
+            JoinedBOMRow(
+                bom_item_id=item.id,
+                part_id=part.id,
+                part_number=part.part_number,
+                reference=item.reference,
+                qty=item.qty,
+                description=part.description,
+                manufacturer=item.manufacturer,
+                active_passive=ap,
+            )
+        )
+    result.sort(key=lambda r: natural_key(r.reference))
+    return result

--- a/app/services/parts.py
+++ b/app/services/parts.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from sqlmodel import Session
+
+from ..models import Part, PartType
+
+
+def update_part_active_passive(
+    session: Session, part_id: int, mode: Literal["active", "passive"]
+) -> Part:
+    """Update a part's active/passive classification."""
+
+    if mode not in ("active", "passive"):
+        raise ValueError("mode must be 'active' or 'passive'")
+    part = session.get(Part, part_id)
+    if part is None:
+        raise ValueError(f"Part {part_id} not found")
+    part.active_passive = PartType(mode)
+    session.add(part)
+    session.commit()
+    session.refresh(part)
+    return part

--- a/tests/test_bom_read_models.py
+++ b/tests/test_bom_read_models.py
@@ -1,0 +1,47 @@
+from importlib import reload
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, create_engine, Session
+
+import app.models as models
+from app.services.bom_read_models import get_joined_bom_for_assembly
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite://",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.clear()
+    reload(models)
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def test_get_joined_bom_for_assembly_sorting_and_fields():
+    engine = setup_db()
+    with Session(engine) as session:
+        cust = models.Customer(name="Cust")
+        session.add(cust)
+        session.commit(); session.refresh(cust)
+        proj = models.Project(customer_id=cust.id, code="PRJ", title="Proj")
+        session.add(proj); session.commit(); session.refresh(proj)
+        asm = models.Assembly(project_id=proj.id, rev="A")
+        session.add(asm); session.commit(); session.refresh(asm)
+        p1 = models.Part(part_number="P1", description="Part1")
+        p2 = models.Part(part_number="P2", description="Part2")
+        session.add(p1); session.add(p2)
+        session.commit(); session.refresh(p1); session.refresh(p2)
+        session.add(models.BOMItem(assembly_id=asm.id, part_id=p1.id, reference="R10", qty=1, manufacturer="M1"))
+        session.add(models.BOMItem(assembly_id=asm.id, part_id=p1.id, reference="R1", qty=1, manufacturer="M1"))
+        session.add(models.BOMItem(assembly_id=asm.id, part_id=p2.id, reference="R2", qty=1, manufacturer="M2"))
+        session.commit()
+        rows = get_joined_bom_for_assembly(session, asm.id)
+        assert [r.reference for r in rows] == ["R1", "R2", "R10"]
+        first = rows[0]
+        assert first.part_number == "P1"
+        assert first.description == "Part1"
+        assert first.manufacturer == "M1"
+        assert first.active_passive == "passive"
+        assert rows[2].part_id == p1.id

--- a/tests/test_parts_updater.py
+++ b/tests/test_parts_updater.py
@@ -1,0 +1,34 @@
+from importlib import reload
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, create_engine, Session
+import pytest
+
+import app.models as models
+from app.services.parts import update_part_active_passive
+
+
+def setup_db():
+    engine = create_engine(
+        "sqlite://",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.clear()
+    reload(models)
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def test_update_part_active_passive():
+    engine = setup_db()
+    with Session(engine) as session:
+        p = models.Part(part_number="P1")
+        session.add(p)
+        session.commit(); session.refresh(p)
+        updated = update_part_active_passive(session, p.id, "active")
+        assert updated.active_passive == models.PartType.active
+        session.refresh(p)
+        assert p.active_passive == models.PartType.active
+        with pytest.raises(ValueError):
+            update_part_active_passive(session, p.id, "foo")


### PR DESCRIPTION
## Summary
- join BOM items with parts via new read-model service and natural reference sorting
- service to update global part active/passive classification
- desktop BOM editor pane with filtering, column visibility, immediate or batch saves, and main window entry

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3fe80f1c0832ca91ce537c5e901a9