### PR TITLE
Add test method columns with placeholder dialogs

### DIFF
--- a/app/gui/dialogs/tm_stub_dialog.py
+++ b/app/gui/dialogs/tm_stub_dialog.py
@@ -1,0 +1,14 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton
+
+
+class TestMethodStubDialog(QDialog):
+    """Simple placeholder dialog for unimplemented test method actions."""
+
+    def __init__(self, message: str, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Not implemented")
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel(message))
+        ok = QPushButton("OK")
+        ok.clicked.connect(self.accept)
+        layout.addWidget(ok)


### PR DESCRIPTION
## Summary
- extend BOM Editor with Test Method and Test Detail columns
- allow per-part method selection with Quick Test file memory and placeholder dialogs for other methods
- add simple stub dialog component for future integrations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b555b930d8832cb07a04dde9589fef