### PR TITLE
Add deterministic autofill and new BOM columns

### DIFF
--- a/app/logic/autofill_rules.py
+++ b/app/logic/autofill_rules.py
@@ -1,0 +1,216 @@
+from dataclasses import dataclass
+from typing import Optional
+import re
+
+@dataclass
+class AutoResult:
+    package: Optional[str] = None
+    value: Optional[str] = None
+    tol_pos: Optional[str] = None
+    tol_neg: Optional[str] = None
+
+# Regex patterns
+_PACK_RE = re.compile(r"(?<!\d)(0201|0402|0603|0805|1206|1210|1812|2010|2512|2220|2225)(?!\d)")
+_CAP_RE = re.compile(r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?)[\s]*?(pF|nF|uF|µF|PF|NF|UF)(?![A-Za-z0-9])", re.I)
+_IND_RE = re.compile(r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?)[\s]*?(nH|uH|µH|mH|H)(?![A-Za-z0-9])", re.I)
+_RES_UNIT_RE = re.compile(r"(?<![A-Za-z0-9])(\d+(?:\.\d+)?)(?:\s*|\s*[- ]?)?(R|Ω|OHM|K|k|M|Meg|G)(?![A-Za-z0-9])", re.I)
+_RES_CODE_TOKEN_RE = re.compile(r"\b\d+[RrKkMm]\d*\b")
+_TOL_ASYM_RE1 = re.compile(r"\+(\d+(?:\.\d+)?)(?:\s*%)?.*-(\d+(?:\.\d+)?)(?:\s*%)", re.I)
+_TOL_ASYM_RE2 = re.compile(r"-(\d+(?:\.\d+)?)(?:\s*%)?.*\+(\d+(?:\.\d+)?)(?:\s*%)", re.I)
+_TOL_SYM_RE = re.compile(r"(?:±|\+/-)?\s*(\d+(?:\.\d+)?)\s*%", re.I)
+_EIA_CODE_RE = re.compile(r"C\d{4}C(\d{3})[A-Z]", re.I)
+_EIA_TOL_RE = re.compile(r"C\d{4}C\d{3}([FGJKM])", re.I)
+_CAP_KEY_RE = re.compile(r"CAP", re.I)
+_RES_KEY_RE = re.compile(r"RES|RESISTOR", re.I)
+_IND_KEY_RE = re.compile(r"IND|INDUCTOR", re.I)
+
+_TOL_MAP = {"F": "1", "G": "2", "J": "5", "K": "10", "M": "20"}
+
+
+def _strip(v: float) -> str:
+    s = f"{v:g}"
+    if "." in s:
+        s = s.rstrip("0").rstrip(".")
+    return s
+
+
+def _cap_to_pf(num: float, unit: str) -> float:
+    u = unit.replace("µ", "u").lower()
+    if u == "pf":
+        return num
+    if u == "nf":
+        return num * 1e3
+    if u == "uf":
+        return num * 1e6
+    return num
+
+
+def _normalize_cap_pf(pf: float) -> str:
+    if pf >= 100000:
+        return f"{_strip(pf/1e6)}uF"
+    if pf >= 1000:
+        return f"{_strip(pf/1e3)}nF"
+    return f"{_strip(pf)}pF"
+
+
+def _res_to_ohms(num: str, unit: str) -> float:
+    n = float(num)
+    u = unit.upper()
+    if u in {"R", "Ω", "OHM", "OHMS"}:
+        return n
+    if u == "K":
+        return n * 1e3
+    if u in {"M", "MEG"}:
+        return n * 1e6
+    if u == "G":
+        return n * 1e9
+    return n
+
+
+def _norm_res_ohms(ohms: float) -> str:
+    if ohms >= 1e6:
+        return f"{_strip(ohms/1e6)}MΩ"
+    if ohms >= 1e3:
+        return f"{_strip(ohms/1e3)}k"
+    return f"{_strip(ohms)}Ω"
+
+
+def _value_from_res_code(token: str) -> Optional[str]:
+    m = re.fullmatch(r"(\d+)([RrKkMm])(\d*)", token)
+    if not m:
+        return None
+    left, letter, right = m.groups()
+    right = right or "0"
+    letter = letter.upper()
+    if letter == "R":
+        ohms = float(f"{left}.{right}" if right != "0" else left)
+    elif letter == "K":
+        ohms = float(f"{left}.{right}") * 1e3
+    elif letter == "M":
+        ohms = float(f"{left}.{right}") * 1e6
+    else:
+        return None
+    return _norm_res_ohms(ohms)
+
+
+def _cap_value_from_desc(desc: str) -> tuple[Optional[str], Optional[float]]:
+    matches = _CAP_RE.findall(desc)
+    if not matches:
+        return None, None
+    pfs = [_cap_to_pf(float(num), unit) for num, unit in matches]
+    norms = {_normalize_cap_pf(pf) for pf in pfs}
+    if len(norms) == 1:
+        return norms.pop(), pfs[0]
+    return None, None
+
+
+def _res_value_from_desc(desc: str) -> Optional[str]:
+    vals = []
+    for num, unit in _RES_UNIT_RE.findall(desc):
+        ohms = _res_to_ohms(num, unit)
+        vals.append(_norm_res_ohms(ohms))
+    for token in _RES_CODE_TOKEN_RE.findall(desc):
+        v = _value_from_res_code(token)
+        if v:
+            vals.append(v)
+    vals = set(vals)
+    if len(vals) == 1:
+        return vals.pop()
+    return None
+
+
+def _ind_value_from_desc(desc: str) -> Optional[str]:
+    matches = _IND_RE.findall(desc)
+    if not matches:
+        return None
+    unit_map = {"nh": "nH", "uh": "uH", "mh": "mH", "h": "H"}
+    vals = {
+        f"{_strip(float(num))}{unit_map.get(unit.replace('µ', 'u').lower(), unit)}"
+        for num, unit in matches
+    }
+    if len(vals) == 1:
+        return vals.pop()
+    return None
+
+
+def _parse_tol(desc: str) -> Optional[tuple[str, str]]:
+    m = _TOL_ASYM_RE1.search(desc)
+    if m:
+        return m.group(1), m.group(2)
+    m = _TOL_ASYM_RE2.search(desc)
+    if m:
+        return m.group(2), m.group(1)
+    nums = _TOL_SYM_RE.findall(desc)
+    nums = [n for n in nums if n]
+    if len(set(nums)) == 1:
+        val = nums[0]
+        return val, val
+    return None
+
+
+def _code_to_pf(code: str) -> float:
+    sig = int(code[:2])
+    exp = int(code[2])
+    return sig * (10 ** exp)
+
+
+def infer_from_pn_and_desc(pn: str, desc: str) -> AutoResult:
+    pn = pn or ""
+    desc = desc or ""
+    res = AutoResult()
+
+    # Package
+    matches = set(_PACK_RE.findall(pn))
+    if len(matches) == 1:
+        res.package = matches.pop()
+    else:
+        matches = set(_PACK_RE.findall(desc))
+        if len(matches) == 1:
+            res.package = matches.pop()
+
+    # Value from description
+    value, pf_desc = _cap_value_from_desc(desc)
+    if value:
+        res.value = value
+    else:
+        vres = _res_value_from_desc(desc)
+        if vres:
+            res.value = vres
+        else:
+            vind = _ind_value_from_desc(desc)
+            if vind:
+                res.value = vind
+
+    # PN helpers
+    if res.value is None:
+        # Capacitor EIA code
+        m = _EIA_CODE_RE.search(pn)
+        if m and (_CAP_KEY_RE.search(desc) or re.search(r"C\d{4}C", pn, re.I)):
+            pf = _code_to_pf(m.group(1))
+            res.value = _normalize_cap_pf(pf)
+    else:
+        # If desc gives capacitor value, ensure PN is consistent if present
+        m = _EIA_CODE_RE.search(pn)
+        if pf_desc is not None and m and (_CAP_KEY_RE.search(desc) or re.search(r"C\d{4}C", pn, re.I)):
+            pf = _code_to_pf(m.group(1))
+            if _normalize_cap_pf(pf) != _normalize_cap_pf(pf_desc):
+                pass  # keep description value
+    # Resistor PN codes if description indicates resistor
+    if res.value is None and _RES_KEY_RE.search(desc):
+        vals = {_value_from_res_code(t) for t in _RES_CODE_TOKEN_RE.findall(pn)}
+        vals.discard(None)
+        if len(vals) == 1:
+            res.value = vals.pop()
+
+    # Tolerance
+    tol = _parse_tol(desc)
+    if tol:
+        res.tol_pos, res.tol_neg = tol
+    else:
+        m = _EIA_TOL_RE.search(pn)
+        if m and (_CAP_KEY_RE.search(desc) or re.search(r"C\d{4}C", pn, re.I)):
+            t = _TOL_MAP.get(m.group(1).upper())
+            if t:
+                res.tol_pos = res.tol_neg = t
+
+    return res

--- a/app/models.py
+++ b/app/models.py
@@ -91,8 +91,8 @@ class Part(SQLModel, table=True):
     active_passive: PartType = Field(default=PartType.passive)
     power_required: bool = False
     datasheet_url: Optional[str] = None
-    tol_p: Optional[str] = None
-    tol_n: Optional[str] = None
+    tol_p: Optional[str] = Field(default=None, max_length=8)
+    tol_n: Optional[str] = Field(default=None, max_length=8)
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -39,7 +39,14 @@ from .assemblies import list_assemblies, list_bom_items, create_assembly, delete
 from .tasks import list_tasks
 from .bom_import import ImportReport, validate_headers, import_bom
 from .bom_read_models import JoinedBOMRow, get_joined_bom_for_assembly
-from .parts import update_part_active_passive, update_part_datasheet_url, update_part_function
+from .parts import (
+    update_part_active_passive,
+    update_part_datasheet_url,
+    update_part_function,
+    update_part_package,
+    update_part_value,
+    update_part_tolerances,
+)
 from .datasheets import (
     DATASHEET_STORE,
     sha256_of_file,
@@ -70,6 +77,9 @@ __all__ = [
     "update_part_active_passive",
     "update_part_datasheet_url",
     "update_part_function",
+    "update_part_package",
+    "update_part_value",
+    "update_part_tolerances",
     "DATASHEET_STORE",
     "sha256_of_file",
     "canonical_path_for_hash",

--- a/app/services/bom_read_models.py
+++ b/app/services/bom_read_models.py
@@ -24,6 +24,10 @@ class JoinedBOMRow(BaseModel):
     description: str | None
     manufacturer: str | None
     function: str | None = None
+    package: str | None = None
+    value: str | None = None
+    tol_p: str | None = None
+    tol_n: str | None = None
     active_passive: Optional[Literal["active", "passive"]] = None
     datasheet_url: str | None = None
 
@@ -50,6 +54,10 @@ def get_joined_bom_for_assembly(session: Session, assembly_id: int) -> List[Join
                 description=part.description,
                 manufacturer=item.manufacturer,
                 function=part.function,
+                package=part.package,
+                value=part.value,
+                tol_p=part.tol_p,
+                tol_n=part.tol_n,
                 active_passive=ap,
                 datasheet_url=part.datasheet_url,
             )

--- a/app/services/parts.py
+++ b/app/services/parts.py
@@ -51,3 +51,45 @@ def update_part_function(session: Session, part_id: int, function: str | None) -
     session.commit()
     session.refresh(part)
     return part
+
+
+def update_part_package(session: Session, part_id: int, package: str) -> Part:
+    """Update a part's package string."""
+
+    part = session.get(Part, part_id)
+    if part is None:
+        raise ValueError(f"Part {part_id} not found")
+    part.package = package
+    session.add(part)
+    session.commit()
+    session.refresh(part)
+    return part
+
+
+def update_part_value(session: Session, part_id: int, value: str) -> Part:
+    """Update a part's value string."""
+
+    part = session.get(Part, part_id)
+    if part is None:
+        raise ValueError(f"Part {part_id} not found")
+    part.value = value
+    session.add(part)
+    session.commit()
+    session.refresh(part)
+    return part
+
+
+def update_part_tolerances(
+    session: Session, part_id: int, tol_p: str | None, tol_n: str | None
+) -> Part:
+    """Update a part's tolerance values."""
+
+    part = session.get(Part, part_id)
+    if part is None:
+        raise ValueError(f"Part {part_id} not found")
+    part.tol_p = tol_p or None
+    part.tol_n = tol_n or None
+    session.add(part)
+    session.commit()
+    session.refresh(part)
+    return part

--- a/tests/test_autofill_integration.py
+++ b/tests/test_autofill_integration.py
@@ -1,0 +1,38 @@
+from app.logic.autofill_rules import infer_from_pn_and_desc
+
+
+def test_autofill_only_fills_empty():
+    rows = [
+        {
+            "pn": "C0603C104K5RAC",
+            "desc": "CHIP CAP 0.1UF 10% 0603",
+            "package": "",
+            "value": "",
+            "tol_pos": "",
+            "tol_neg": "",
+        },
+        {
+            "pn": "R0603-10K",
+            "desc": "RES 10K 1%",
+            "package": "0603",
+            "value": "1k",
+            "tol_pos": "",
+            "tol_neg": "",
+        },
+    ]
+
+    for row in rows:
+        res = infer_from_pn_and_desc(row["pn"], row["desc"])
+        if res.package and not row["package"]:
+            row["package"] = res.package
+        if res.value and not row["value"]:
+            row["value"] = res.value
+        if res.tol_pos and res.tol_neg and not row["tol_pos"] and not row["tol_neg"]:
+            row["tol_pos"] = res.tol_pos
+            row["tol_neg"] = res.tol_neg
+
+    assert rows[0]["package"] == "0603" and rows[0]["value"] == "0.1uF"
+    assert rows[0]["tol_pos"] == "10" and rows[0]["tol_neg"] == "10"
+    # Second row retains existing non-empty fields
+    assert rows[1]["package"] == "0603"
+    assert rows[1]["value"] == "1k"

--- a/tests/test_autofill_rules.py
+++ b/tests/test_autofill_rules.py
@@ -1,0 +1,54 @@
+import pytest
+from app.logic.autofill_rules import infer_from_pn_and_desc
+
+
+def test_package_inference():
+    r = infer_from_pn_and_desc("C0603C104K5RAC", "")
+    assert r.package == "0603"
+    r = infer_from_pn_and_desc("", "CHIP CAP 2.2UF 16V 0603 T&R")
+    assert r.package == "0603"
+    r = infer_from_pn_and_desc("PN0603-0805", "mix 0603 0805")
+    assert r.package is None
+
+
+def test_cap_value_from_desc():
+    r = infer_from_pn_and_desc("", "CHIP CAP 0.1UF 10% 50V")
+    assert r.value == "0.1uF"
+
+
+def test_cap_value_from_pn_eia():
+    r = infer_from_pn_and_desc("C0402C101G5GACTU", "")
+    assert r.value == "100pF"
+    r = infer_from_pn_and_desc("C0603C106M", "")
+    assert r.value == "10uF"
+
+
+def test_res_value_from_desc():
+    r = infer_from_pn_and_desc("", "RES 10K 1%")
+    assert r.value == "10k"
+    r = infer_from_pn_and_desc("", "RES 4R7 5%")
+    assert r.value == "4.7Ω"
+
+
+def test_ind_value_from_desc():
+    r = infer_from_pn_and_desc("", "IND 4.7uH")
+    assert r.value == "4.7uH"
+
+
+def test_tolerance_from_desc():
+    r = infer_from_pn_and_desc("", "CAP 0.1UF 10%")
+    assert (r.tol_pos, r.tol_neg) == ("10", "10")
+    r = infer_from_pn_and_desc("", "+10/-5% CAP")
+    assert (r.tol_pos, r.tol_neg) == ("10", "5")
+
+
+def test_tolerance_from_pn_letter():
+    r = infer_from_pn_and_desc("C0603C104K5RAC", "CHIP CAP")
+    assert (r.tol_pos, r.tol_neg) == ("10", "10")
+
+
+def test_conflict_desc_vs_eia():
+    r = infer_from_pn_and_desc("C0603C102K", "CAP 0.1UF")
+    assert r.value == "0.1uF"
+    r = infer_from_pn_and_desc("C0603C102K", "CAP CER")
+    assert r.value == "1nF"

--- a/tests/test_parts_updater.py
+++ b/tests/test_parts_updater.py
@@ -4,7 +4,12 @@ from sqlmodel import SQLModel, create_engine, Session
 import pytest
 
 import app.models as models
-from app.services.parts import update_part_active_passive
+from app.services.parts import (
+    update_part_active_passive,
+    update_part_package,
+    update_part_value,
+    update_part_tolerances,
+)
 
 
 def setup_db():
@@ -32,3 +37,27 @@ def test_update_part_active_passive():
         assert p.active_passive == models.PartType.active
         with pytest.raises(ValueError):
             update_part_active_passive(session, p.id, "foo")
+
+
+def test_update_part_package_value():
+    engine = setup_db()
+    with Session(engine) as session:
+        p = models.Part(part_number="P1")
+        session.add(p)
+        session.commit(); session.refresh(p)
+        update_part_package(session, p.id, "0603")
+        update_part_value(session, p.id, "10k")
+        session.refresh(p)
+        assert p.package == "0603"
+        assert p.value == "10k"
+
+
+def test_update_part_tolerances():
+    engine = setup_db()
+    with Session(engine) as session:
+        p = models.Part(part_number="P1")
+        session.add(p)
+        session.commit(); session.refresh(p)
+        update_part_tolerances(session, p.id, "10", "5")
+        session.refresh(p)
+        assert p.tol_p == "10" and p.tol_n == "5"


### PR DESCRIPTION
## Summary
- add package, value, and tolerance columns to BOM editor with persistence per part
- implement deterministic PN/description-based autofill rules
- extend services and read models for package/value fields
- persist tol± values in the Part model and allow editing/autofill to update the database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86a0d8e4c832cb6e4360181003e43