### PR TITLE
Add BOM item deletion helpers and GUI undo stack

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -35,7 +35,14 @@ from .customers import (
     DeleteBlockedError,
 )
 from .projects import list_projects, create_project, delete_project
-from .assemblies import list_assemblies, list_bom_items, create_assembly, delete_assembly
+from .assemblies import (
+    list_assemblies,
+    list_bom_items,
+    create_assembly,
+    delete_assembly,
+    delete_bom_items,
+    delete_bom_items_for_part,
+)
 from .tasks import list_tasks
 from .bom_import import ImportReport, validate_headers, import_bom
 from .bom_read_models import JoinedBOMRow, get_joined_bom_for_assembly
@@ -46,6 +53,7 @@ from .parts import (
     update_part_package,
     update_part_value,
     update_part_tolerances,
+    clear_part_datasheet,
 )
 from .export_viva import build_viva_groups, write_viva_txt
 from .datasheets import (
@@ -66,6 +74,8 @@ __all__ = [
     "list_bom_items",
     "create_assembly",
     "delete_assembly",
+    "delete_bom_items",
+    "delete_bom_items_for_part",
     "delete_customer",
     "DeleteBlockedError",
     "list_tasks",
@@ -81,6 +91,7 @@ __all__ = [
     "update_part_package",
     "update_part_value",
     "update_part_tolerances",
+    "clear_part_datasheet",
     "build_viva_groups",
     "write_viva_txt",
     "DATASHEET_STORE",

--- a/app/services/parts.py
+++ b/app/services/parts.py
@@ -93,3 +93,16 @@ def update_part_tolerances(
     session.commit()
     session.refresh(part)
     return part
+
+
+def clear_part_datasheet(session: Session, part_id: int) -> Part:
+    """Clear the datasheet association for a part.
+
+    This is a thin wrapper around :func:`update_part_datasheet_url` that sets
+    the ``datasheet_url`` field to ``None``.  The physical datasheet file is
+    intentionally left untouched so that other parts may continue to reference
+    it.
+    """
+
+    # ``update_part_datasheet_url`` performs validation and commits the change.
+    return update_part_datasheet_url(session, part_id, None)


### PR DESCRIPTION
## Summary
- add service helpers to delete BOM items individually or per-part and expose via service API
- support clearing a part's datasheet association
- replace manual undo/redo in BOM editor with a QUndoStack-based implementation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb216c3d28832c95bab08b32056a8e