### PR TITLE
Ensure sqlmodel included in bundled builds

### DIFF
--- a/BOM_DB.spec
+++ b/BOM_DB.spec
@@ -6,6 +6,7 @@ binaries = []
 hiddenimports = []
 tmp_ret = collect_all('PyQt6')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+hiddenimports += ["sqlmodel"]
 
 # sqlmodel is a runtime dependency that PyInstaller fails to detect because it
 # is mostly used via SQLAlchemy style imports.  Explicitly collect it so the

--- a/scripts/build_exe.ps1
+++ b/scripts/build_exe.ps1
@@ -32,6 +32,7 @@ $args = @(
     "--noconfirm",
     "--clean",
     "--windowed",
+    "--hidden-import", "sqlmodel",
     "--name", $Name
 ) + $addDataArgs + @(
     "-m", "app.gui"


### PR DESCRIPTION
## Summary
- install project dependencies during the shell build script, verify sqlmodel imports, and ensure it is passed as a hidden import to PyInstaller
- add sqlmodel to the hidden imports in the spec file and powershell build script to keep builds consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e36efed748832c906f55324047f35f