### PR TITLE
Ensure packaged app bundles portable assets

### DIFF
--- a/BOM_DB.spec
+++ b/BOM_DB.spec
@@ -1,5 +1,9 @@
 # -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
 from PyInstaller.utils.hooks import collect_all
+
+repo_root = Path(__file__).resolve().parent
 
 datas = [('app/gui/icons', 'app/gui/icons')]
 binaries = []
@@ -7,6 +11,39 @@ hiddenimports = []
 tmp_ret = collect_all('PyQt6')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 hiddenimports += ["sqlmodel"]
+
+
+def _add_tree(src: Path, dest_root: Path) -> None:
+    if not src.exists():
+        return
+    for path in src.rglob('*'):
+        if path.is_dir():
+            continue
+        if any(part == '__pycache__' for part in path.parts):
+            continue
+        rel = path.relative_to(src)
+        datas.append((str(path), str(dest_root / rel)))
+
+
+portable_roots = {
+    repo_root / 'app': Path('internal/app'),
+    repo_root / 'data': Path('internal/data'),
+    repo_root / 'static': Path('internal/static'),
+    repo_root / 'migrations': Path('internal/migrations'),
+}
+
+for src_dir, dest in portable_roots.items():
+    _add_tree(src_dir, dest)
+
+portable_files = [
+    (repo_root / 'bom_template.csv', Path('internal/bom_template.csv')),
+    (repo_root / 'agents.example.toml', Path('internal/agents.example.toml')),
+    (repo_root / 'agents.local.toml', Path('internal/agents.local.toml')),
+]
+
+for src_file, dest_file in portable_files:
+    if src_file.exists():
+        datas.append((str(src_file), str(dest_file)))
 
 
 block_cipher = None

--- a/app/gui/bom_editor_pane.py
+++ b/app/gui/bom_editor_pane.py
@@ -46,7 +46,7 @@ from PyQt6.QtGui import QPainter, QBrush, QColor, QDesktopServices, QGuiApplicat
 import logging
 from .. import services
 from ..services.datasheets import get_local_open_path
-from ..config import PDF_VIEWER, PDF_VIEWER_PATH, PDF_OPEN_DEBUG, get_complex_editor_settings
+from ..config import DATA_ROOT, PDF_VIEWER, PDF_VIEWER_PATH, PDF_OPEN_DEBUG, get_complex_editor_settings
 import subprocess, shutil, time, os
 from datetime import datetime
 from ..logic.autofill_rules import infer_from_pn_and_desc
@@ -2115,6 +2115,7 @@ QTableView::item:selected:hover {
             candidates.append(Path.cwd() / "data" / "function_list.txt")
         except Exception:
             candidates.append(Path.cwd() / "data" / "function_list.txt")
+        candidates.append(DATA_ROOT / "function_list.txt")
         for p in candidates:
             try:
                 if p.exists():

--- a/app/services/bom_import.py
+++ b/app/services/bom_import.py
@@ -16,7 +16,7 @@ from sqlmodel import Session, select
 from sqlalchemy.exc import IntegrityError
 
 from ..models import Assembly, BOMItem, Part, PartType
-from ..config import get_complex_editor_settings
+from ..config import DATASHEETS_DIR, get_complex_editor_settings
 from ..domain.complex_linker import auto_link_by_pn
 from ..integration.ce_bridge_client import CENetworkError
 from ..integration.ce_bridge_manager import CEBridgeError, ensure_ce_bridge_ready
@@ -170,13 +170,11 @@ def _iter_rows(data: bytes) -> tuple[list[str], list[list[str]]]:
         headers = rows[0] if rows else []
         return headers, rows[1:]
 
-
 # ---------------------------------------------------------------------------
 # Datasheet caching
 
 
-DATASHEETS_DIR = Path("datasheets")
-DATASHEETS_DIR.mkdir(exist_ok=True)
+DATASHEETS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _safe_pn(pn: str) -> str:

--- a/gui/widgets/quick_actions.py
+++ b/gui/widgets/quick_actions.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from app import config
+
 from PySide6.QtWidgets import QPushButton, QVBoxLayout, QWidget
 
 from ..api_client import BaseClient
@@ -54,6 +56,14 @@ class QuickActions(QWidget):
     # ------------------------------------------------------------------
     def seed_sample(self) -> None:
         tpl = Path("bom_template.csv")
+        for candidate in (
+            config.APP_STORAGE_ROOT / "bom_template.csv",
+            config.DATA_ROOT / "bom_template.csv",
+        ):
+            if tpl.exists():
+                break
+            if candidate.exists():
+                tpl = candidate
         if not tpl.exists():
             resp = self._client.get("/bom/template")
             if resp.status_code == 200:


### PR DESCRIPTION
## Summary
- ensure the configuration prefers an `internal` folder for frozen builds and eagerly creates the data and datasheet directories
- teach GUI helpers and the BOM importer to resolve resources from the shared configuration paths
- expand the PyInstaller spec so the generated build includes the source, data, template, and agent files inside an `internal` folder alongside the executable

## Testing
- pytest *(fails: missing optional GUI dependencies and legacy database symbol)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f1d89020832c8f7f953cf5158f07