### PR TITLE
Fix TypedDict import compatibility for Python 3.7 builds

### DIFF
--- a/app/ai_agents.py
+++ b/app/ai_agents.py
@@ -10,8 +10,13 @@ from __future__ import annotations
 
 from pathlib import Path
 import os
-from typing import Dict, Optional, TypedDict
+from typing import Dict, Optional
 import logging
+
+try:  # Python 3.8+
+    from typing import TypedDict
+except ImportError:  # pragma: no cover - Python 3.7 fallback
+    from typing_extensions import TypedDict
 
 from .config import get_agents_file_path
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ toml
 reportlab
 PySide6
 PyQt6
+typing-extensions


### PR DESCRIPTION
## Summary
- add a runtime fallback to import TypedDict from typing_extensions when running on Python 3.7
- add typing-extensions to the project requirements so the fallback dependency is available during packaging

## Testing
- pytest *(fails: requires system OpenGL libraries and database engine export not available in test env)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f8708194832c85df669f190e03a2